### PR TITLE
Update MKL and LAPACK flags

### DIFF
--- a/Solver/Makefile.in
+++ b/Solver/Makefile.in
@@ -121,7 +121,7 @@ ifeq '$(FC)''gfortran'
 else #ifort
     ifeq '$(WITH_MKL)''y'
         MACROS+= -DHAS_LAPACK -DHAS_MKL
-        FFLAGS+= -mkl
+        FFLAGS+= -qmkl
     else ifeq '$(WITH_LAPACK)''y'
         MACROS+= -DHAS_LAPACK
         LIBS+= $(LIB_BLAS) $(LIB_LAPACK)

--- a/Solver/Makefile.in
+++ b/Solver/Makefile.in
@@ -108,16 +108,25 @@ else ifeq ($(MODE),DEBUG)
 endif
 
 ##########################
-## 	Link MKL 	##
+## 	Link LAPACK & MKL	##
 ##########################
-ifeq '$(WITH_MKL)''y'
-	ifeq '$(FC)''gfortran'
-		MACROS+= -DHAS_MKL -DHAS_LAPACK
-  	LIBS += $(LIB_BLAS) $(LIB_LAPACK)
-  else #ifort
-  	MACROS+= -DHAS_MKL -DHAS_LAPACK
-  	FFLAGS+= -mkl
-  endif
+ifeq '$(FC)''gfortran'
+    ifeq '$(WITH_MKL)''y'
+        $(error gfortran and MKL!)
+    else ifeq '$(WITH_LAPACK)''y'
+        MACROS+= -DHAS_LAPACK
+        LIBS+= $(LIB_BLAS) $(LIB_LAPACK)
+        FFLAGS+= -lblas -llapack
+    endif
+else #ifort
+    ifeq '$(WITH_MKL)''y'
+        MACROS+= -DHAS_LAPACK -DHAS_MKL
+        FFLAGS+= -mkl
+    else ifeq '$(WITH_LAPACK)''y'
+        MACROS+= -DHAS_LAPACK
+        LIBS+= $(LIB_BLAS) $(LIB_LAPACK)
+        FFLAGS+= -lblas -llapack
+    endif
 endif
 
 ##########################

--- a/Solver/test/Components/Makefile.gradients
+++ b/Solver/test/Components/Makefile.gradients
@@ -255,16 +255,25 @@ ifeq '$(WITH_PETSC)''y'
 endif
 
 ##########################
-## 	Link MKL 	##
+## 	Link LAPACK & MKL	##
 ##########################
-ifeq '$(WITH_MKL)''y'
-	ifeq '$(FC)''gfortran'
-		MACROS+= -DHAS_MKL -DHAS_LAPACK
-  	LIBS += $(LIB_BLAS) $(LIB_LAPACK)
-  else #ifort
-  	MACROS+= -DHAS_MKL
-  	FCFLAGS+= -mkl
-  endif
+ifeq '$(FC)''gfortran'
+    ifeq '$(WITH_MKL)''y'
+        $(error gfortran and MKL!)
+    else ifeq '$(WITH_LAPACK)''y'
+        MACROS+= -DHAS_LAPACK
+        LIBS+= $(LIB_BLAS) $(LIB_LAPACK)
+        FFLAGS+= -lblas -llapack
+    endif
+else #ifort
+    ifeq '$(WITH_MKL)''y'
+        MACROS+= -DHAS_LAPACK -DHAS_MKL
+        FFLAGS+= -mkl
+    else ifeq '$(WITH_LAPACK)''y'
+        MACROS+= -DHAS_LAPACK
+        LIBS+= $(LIB_BLAS) $(LIB_LAPACK)
+        FFLAGS+= -lblas -llapack
+    endif
 endif
 
 ##########################################

--- a/Solver/test/Components/Makefile.gradients
+++ b/Solver/test/Components/Makefile.gradients
@@ -268,7 +268,7 @@ ifeq '$(FC)''gfortran'
 else #ifort
     ifeq '$(WITH_MKL)''y'
         MACROS+= -DHAS_LAPACK -DHAS_MKL
-        FFLAGS+= -mkl
+        FFLAGS+= -qmkl
     else ifeq '$(WITH_LAPACK)''y'
         MACROS+= -DHAS_LAPACK
         LIBS+= $(LIB_BLAS) $(LIB_LAPACK)


### PR DESCRIPTION
Remove deprecation warning from ifort with -mkl flag, and separate MKL from LAPACK since MKL adds more functionality on top of LAPACK.

Closes #114.