### PR TITLE
Delete temp file when using "hsol files pattern"

### DIFF
--- a/Solver/src/addons/horses2tecplot/getTask.f90
+++ b/Solver/src/addons/horses2tecplot/getTask.f90
@@ -221,6 +221,7 @@ module getTask
                 read(fID, '(A)') solutionNames(i)
                 solutionTypes(i) = getSolutionFileType(solutionNames(i))
             end do 
+            close(fID, status="delete")
          end if
 !
 !        Select the output file type


### PR DESCRIPTION
When using the "hsol files pattern" option in a control file for `horses2plt`, we create a temporary file to store the output of `ls [hsol files pattern]` and then read it. We are not deleting this file, so after running `horses2plt` this new file remains in the folder. I don't know if this behaviour is expected, but I think it can confuse non-developers.

This PR fixes this, we can merge if you think this is better than what we have now.