### PR TITLE
horsesConverter-Fixed mistake on Reference Values for Mapping Result

### DIFF
--- a/Solver/src/addons/horsesConverter/convertSolution.f90
+++ b/Solver/src/addons/horsesConverter/convertSolution.f90
@@ -77,10 +77,10 @@ MODULE convertSolution
             call mesh % ReadMesh(meshFile1)
 			call mesh2 % ReadMesh(meshFile2)
 			
+			call mesh % ReadSolution(resultFile1)
+			
 			mesh2 % refs = mesh % refs
 			mesh2 % time = mesh % time
-			
-			call mesh % ReadSolution(resultFile1)
 			
 			Nout=polyOrder
 			


### PR DESCRIPTION
I realized there is a mistake on transfering reference value and time for horsesConverter (AddOns)-MappingResult. 