### PR TITLE
Run SSPRK tests of CI_parallel in parallel

### DIFF
--- a/.github/workflows/CI_parallel.yml
+++ b/.github/workflows/CI_parallel.yml
@@ -674,7 +674,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/ForwardFacingStep_SSPRK33
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          ./horses3d.ns FFS_SSPRK33.control
+          mpiexec -n 8 ./horses3d.ns FFS_SSPRK33.control
         if: always()
 
 #
@@ -692,7 +692,7 @@ jobs:
         working-directory: ./Solver/test/NavierStokes/ForwardFacingStep_SSPRK43
         run: |
           source /opt/intel/oneapi/setvars.sh || true
-          ./horses3d.ns FFS_SSPRK43.control
+          mpiexec -n 8 ./horses3d.ns FFS_SSPRK43.control
         if: always()
 
 #


### PR DESCRIPTION
Tests 20 and 21 were not running in parallel. They now use `mpiexec -n 8` as all the other tests.