### PR TITLE
WIP: Contiguous memory layout for the solution

### DIFF
--- a/Solver/src/libs/discretization/ShockCapturingKeywords.f90
+++ b/Solver/src/libs/discretization/ShockCapturingKeywords.f90
@@ -17,9 +17,6 @@ module ShockCapturingKeywords
    character(len=*), parameter :: SC_VARIABLE_KEY       = "sensor variable"
    character(len=*), parameter :: SC_LOW_THRES_KEY      = "sensor lower limit"
    character(len=*), parameter :: SC_HIGH_THRES_KEY     = "sensor higher limit"
-   character(len=*), parameter :: SC_TE_NMIN_KEY        = "sensor te min n"
-   character(len=*), parameter :: SC_TE_DELTA_KEY       = "sensor te delta n"
-   character(len=*), parameter :: SC_TE_DTYPE_KEY       = "sensor te derivative"
    character(len=*), parameter :: SC_NUM_CLUSTERS_KEY   = "sensor number of clusters"
    character(len=*), parameter :: SC_SENSOR_INERTIA_KEY = "sensor min. timesteps"
 !
@@ -30,8 +27,6 @@ module ShockCapturingKeywords
    character(len=*), parameter :: SC_INTEGRAL_VAL      = "integral"
    character(len=*), parameter :: SC_INTEGRAL_SQRT_VAL = "integral with sqrt"
    character(len=*), parameter :: SC_MODAL_VAL         = "modal"
-   character(len=*), parameter :: SC_TE_VAL            = "truncation error"
-   character(len=*), parameter :: SC_ALIAS_VAL         = "aliasing error"
    character(len=*), parameter :: SC_GMM_VAL           = "gmm"
 
    integer, parameter :: SC_ZERO_ID          = 1
@@ -39,9 +34,7 @@ module ShockCapturingKeywords
    integer, parameter :: SC_INTEGRAL_ID      = 3
    integer, parameter :: SC_INTEGRAL_SQRT_ID = 4
    integer, parameter :: SC_MODAL_ID         = 5
-   integer, parameter :: SC_TE_ID            = 6
-   integer, parameter :: SC_ALIAS_ID         = 7
-   integer, parameter :: SC_GMM_ID           = 8
+   integer, parameter :: SC_GMM_ID           = 6
 !
 !  Shock-capturing methods
 !  -----------------------
@@ -96,10 +89,5 @@ module ShockCapturingKeywords
    integer, parameter :: SC_RHO_GRAD_ID    = 11
    integer, parameter :: SC_DIVV_ID        = 12
    integer, parameter :: SC_DIVV_P_GRAD_ID = 13
-!
-!  Derivative types
-!  ----------------
-   character(len=*), parameter :: SC_ISOLATED_KEY     = "isolated"
-   character(len=*), parameter :: SC_NON_ISOLATED_KEY = "non-isolated"
 
 end module ShockCapturingKeywords

--- a/Solver/src/libs/jacobian/MatrixFreeClass.f90
+++ b/Solver/src/libs/jacobian/MatrixFreeClass.f90
@@ -91,15 +91,12 @@ module MatrixFreeClass
          
          ! Obtain derivative with new Q
          p_sem % mesh % storage % Q = u
-         call p_sem % mesh % storage % global2LocalQ
          call ComputeTimeDerivative(p_sem % mesh, p_sem % particles, CTD_time, CTD_IGNORE_MODE)
-         call p_sem % mesh % storage % local2GlobalQdot(p_sem % NDOF)
          
          F = p_sem % mesh % storage % Qdot
 
          ! Restore original Q
          p_sem % mesh % storage % Q = u_p   ! TODO: this step can be avoided if Ur is not read in the "child" GMRES (the preconditioner)
-         call p_sem % mesh % storage % global2LocalQ
       end function MF_p_F
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Solver/src/libs/jacobian/NumericalJacobian.f90
+++ b/Solver/src/libs/jacobian/NumericalJacobian.f90
@@ -291,7 +291,6 @@ contains
       if (present(eps_in)) then
          eps = eps_in
       else
-         call sem % mesh % storage % local2GlobalQ (sem % NDOF)
          associate (Q => sem % mesh % storage % Q)
          eps = sqrt(EPSILON(eps))*(NORM2(Q)+1._RP) ! 1.e-8_RP: Sometimes gives better results
          end associate
@@ -355,8 +354,6 @@ contains
       call sem % mesh % SetStorageToEqn(C_BC)
 #endif
       
-      call sem % mesh % storage % local2GlobalQdot (sem % NDOF)
-      call sem % mesh % storage % local2GlobalQ    (sem % NDOF)
       QDot0 = sem % mesh % storage % QDot
       Q0    = sem % mesh % storage % Q
 !
@@ -435,9 +432,7 @@ contains
 !$omp end do
 #endif
 
-               call sem % mesh % storage % local2GlobalQdot (sem %NDOF)
                sem % mesh % storage % QDot = (sem % mesh % storage % QDot - QDot0) / eps
-               call sem % mesh % storage % global2LocalQdot
                
    !
    !           Add the contributions to the Jacobian
@@ -464,7 +459,6 @@ contains
    !           Restore original values for Q (TODO: this can be improved)
    !           ----------------------------------------------------------
                sem % mesh % storage % Q = Q0
-               call sem % mesh % storage % global2LocalQ
 
             ENDDO ! thisdof = 1, ndofcol(thiscolor)
          ENDDO ! thiscolor = 1 , ecolors % num_of_colors
@@ -526,9 +520,7 @@ contains
 !$omp end do
 #endif
 
-            call sem % mesh % storage % local2GlobalQdot (sem %NDOF)
             sem % mesh % storage % QDot = (sem % mesh % storage % QDot - QDot0) / eps
-            call sem % mesh % storage % global2LocalQdot
             
 !
 !           Add the contributions to the Jacobian
@@ -547,7 +539,6 @@ contains
 !           Restore original values for Q (TODO: this can be improved)
 !           ----------------------------------------------------------
             sem % mesh % storage % Q = Q0
-            call sem % mesh % storage % global2LocalQ
          ENDDO
       ENDDO
 

--- a/Solver/src/libs/mesh/HexElementClass.f90
+++ b/Solver/src/libs/mesh/HexElementClass.f90
@@ -89,7 +89,7 @@
             procedure   :: ProlongGradientsToFaces => HexElement_ProlongGradientsToFaces
             procedure   :: ProlongAviscFluxToFaces => HexElement_ProlongAviscFluxToFaces
             procedure   :: ComputeLocalGradient    => HexElement_ComputeLocalGradient
-            procedure   :: pAdapt                  => HexElement_pAdapt
+            ! procedure   :: pAdapt                  => HexElement_pAdapt
             procedure   :: copy                    => HexElement_Assign
             procedure   :: ConstructIBM            => HexElement_ConstructIBM
             generic     :: assignment(=)           => copy
@@ -775,45 +775,45 @@
 !  Adapts an element to new polynomial orders NNew
 !  -> TODO: Previous solutions are not implemented
 !  --------------------------------------------------------
-      subroutine HexElement_pAdapt (self, NNew, nodes, saveGradients, prevSol_num)
-         implicit none
-         !-arguments--------------------------------------------
-         class(Element), intent(inout) :: self
-         integer       , intent(in)    :: NNew(NDIM)
-         integer       , intent(in)    :: nodes
-         logical       , intent(in)    :: saveGradients
-         integer       , intent(in)    :: prevSol_num
-         !-arguments--------------------------------------------
-         logical                       :: anJacobian
-         type(ElementStorage_t)        :: tempStorage
-#if (!defined(NAVIERSTOKES))
-         logical, parameter            :: computeGradients = .true.
-#endif
-         !-----------------------------------------------------
+!       subroutine HexElement_pAdapt (self, NNew, nodes, saveGradients, prevSol_num)
+!          implicit none
+!          !-arguments--------------------------------------------
+!          class(Element), intent(inout) :: self
+!          integer       , intent(in)    :: NNew(NDIM)
+!          integer       , intent(in)    :: nodes
+!          logical       , intent(in)    :: saveGradients
+!          integer       , intent(in)    :: prevSol_num
+!          !-arguments--------------------------------------------
+!          logical                       :: anJacobian
+!          type(ElementStorage_t)        :: tempStorage
+! #if (!defined(NAVIERSTOKES))
+!          logical, parameter            :: computeGradients = .true.
+! #endif
+!          !-----------------------------------------------------
 
-!
-!        Reconstruct storage
-!        -------------------
+! !
+! !        Reconstruct storage
+! !        -------------------
 
-         anJacobian = self % storage % anJacobian
+!          anJacobian = self % storage % anJacobian
 
-         call tempStorage % construct (self % Nxyz(1), self % Nxyz(2), self % Nxyz(3), computeGradients, anJacobian, prevSol_num,0)
-         tempStorage = self % storage
+!          call tempStorage % construct (self % Nxyz(1), self % Nxyz(2), self % Nxyz(3), computeGradients, anJacobian, prevSol_num,0)
+!          tempStorage = self % storage
 
-         self % Nxyz = NNew
-         self % hn = (self % geom % Volume / product(self % Nxyz + 1)) ** (1.0_RP / 3.0_RP)
+!          self % Nxyz = NNew
+!          self % hn = (self % geom % Volume / product(self % Nxyz + 1)) ** (1.0_RP / 3.0_RP)
 
-         call self % storage % destruct()
-         call self % storage % construct ( NNew(1), NNew(2), NNew(3), computeGradients, anJacobian, prevSol_num,0)
+!          call self % storage % destruct()
+!          call self % storage % construct ( NNew(1), NNew(2), NNew(3), computeGradients, anJacobian, prevSol_num,0)
 
-         call tempStorage % InterpolateSolution (self % storage, nodes, saveGradients)
+!          call tempStorage % InterpolateSolution (self % storage, nodes, saveGradients)
 
-         if (prevSol_num > 0) then
-            ! TODO : call InterpolatePrevSol
-         end if
-         call tempStorage % destruct()
+!          if (prevSol_num > 0) then
+!             ! TODO : call InterpolatePrevSol
+!          end if
+!          call tempStorage % destruct()
 
-      end subroutine HexElement_pAdapt
+!       end subroutine HexElement_pAdapt
 
       pure subroutine SurfInfo_Destruct (self)
          implicit none

--- a/Solver/src/libs/mesh/HexMesh.f90
+++ b/Solver/src/libs/mesh/HexMesh.f90
@@ -93,7 +93,7 @@ MODULE HexMeshClass
             procedure :: ExportOrders                  => HexMesh_ExportOrders
             procedure :: ExportBoundaryMesh            => HexMesh_ExportBoundaryMesh
             procedure :: SaveSolution                  => HexMesh_SaveSolution
-            procedure :: pAdapt                        => HexMesh_pAdapt
+            ! procedure :: pAdapt                        => HexMesh_pAdapt
 #if defined(NAVIERSTOKES)
             procedure :: SaveStatistics                => HexMesh_SaveStatistics
             procedure :: ResetStatistics               => HexMesh_ResetStatistics
@@ -3157,15 +3157,6 @@ slavecoord:             DO l = 1, 4
                call auxMesh % storage % elements (eID) % InterpolateSolution (self % storage % elements(eID), auxMesh % nodeType , with_gradients)
             end do
 
-!           Clean up
-!           --------
-
-            do eID = 1, auxMesh % no_of_elements
-               call auxMesh % elements(eID) % storage % destruct
-            end do
-            call auxMesh % storage % destruct
-            deallocate (auxMesh % elements)
-
             if ( controlVariables % containsKey("get discretization error of") ) call GetDiscretizationError(self,controlVariables)
 !
 !        *****************************************************
@@ -3431,15 +3422,6 @@ slavecoord:             DO l = 1, 4
       print*, '|disc_error|² = ', norm2(refMesh % storage % Q)
 
       call refMesh % SaveSolution(0, 0._RP, 'RESULTS/DiscError.hsol', .FALSE.)
-
-!           Clean up
-!           --------
-
-      do eID = 1, refMesh % no_of_elements
-         call refMesh % elements(eID) % storage % destruct
-      end do
-      call refMesh % storage % destruct
-      deallocate (refMesh % elements)
 
    end subroutine GetDiscretizationError
 !
@@ -4048,178 +4030,178 @@ slavecoord:             DO l = 1, 4
 !  --------------------------------------------------------
 !  Adapts a mesh to new polynomial orders NNew
 !  --------------------------------------------------------
-   subroutine HexMesh_pAdapt (self, NNew, controlVariables)
-      implicit none
-      !-arguments-----------------------------------------
-      class(HexMesh), target  , intent(inout)   :: self
-      integer                 , intent(in)      :: NNew(NDIM,self % no_of_elements)
-      type(FTValueDictionary) , intent(in)      :: controlVariables
-      !-local-variables-----------------------------------
-      integer :: eID, fID, zoneID
-      logical :: saveGradients, FaceComputeQdot
-      logical :: analyticalJac   ! Do we need analytical Jacobian storage?
-      type(IntegerDataLinkedList_t) :: elementList
-      type(IntegerDataLinkedList_t) :: facesList
-      type(IntegerDataLinkedList_t) :: zoneList
-      integer         , allocatable :: zoneArray(:)
-      integer         , allocatable :: facesArray(:)
-      integer         , allocatable :: elementArray(:)
-      type(Zone_t)    , pointer :: zone
-      type(Element)   , pointer :: e
-      type(Face)      , pointer :: f
-#if (!defined(NAVIERSTOKES))
-      logical, parameter            :: computeGradients = .true.
-#endif
-      !---------------------------------------------------
+!    subroutine HexMesh_pAdapt (self, NNew, controlVariables)
+!       implicit none
+!       !-arguments-----------------------------------------
+!       class(HexMesh), target  , intent(inout)   :: self
+!       integer                 , intent(in)      :: NNew(NDIM,self % no_of_elements)
+!       type(FTValueDictionary) , intent(in)      :: controlVariables
+!       !-local-variables-----------------------------------
+!       integer :: eID, fID, zoneID
+!       logical :: saveGradients, FaceComputeQdot
+!       logical :: analyticalJac   ! Do we need analytical Jacobian storage?
+!       type(IntegerDataLinkedList_t) :: elementList
+!       type(IntegerDataLinkedList_t) :: facesList
+!       type(IntegerDataLinkedList_t) :: zoneList
+!       integer         , allocatable :: zoneArray(:)
+!       integer         , allocatable :: facesArray(:)
+!       integer         , allocatable :: elementArray(:)
+!       type(Zone_t)    , pointer :: zone
+!       type(Element)   , pointer :: e
+!       type(Face)      , pointer :: f
+! #if (!defined(NAVIERSTOKES))
+!       logical, parameter            :: computeGradients = .true.
+! #endif
+!       !---------------------------------------------------
 
-!     **************************************
-!     Check if resulting mesh is anisotropic
-!     **************************************
-      if ( maxval(NNew) /= minval(NNew) ) self % anisotropic = .TRUE.
+! !     **************************************
+! !     Check if resulting mesh is anisotropic
+! !     **************************************
+!       if ( maxval(NNew) /= minval(NNew) ) self % anisotropic = .TRUE.
 
-      self % NDOF = 0
-      do eID=1, self % no_of_elements
-         self % NDOF = self % NDOF + product( NNew(:,eID) + 1 )
-      end do
+!       self % NDOF = 0
+!       do eID=1, self % no_of_elements
+!          self % NDOF = self % NDOF + product( NNew(:,eID) + 1 )
+!       end do
 
-!     ********************
-!     Some initializations
-!     ********************
-      saveGradients = controlVariables % logicalValueForKey("save gradients with solution")
-      FaceComputeQdot = controlVariables % containsKey("acoustic analogy")
+! !     ********************
+! !     Some initializations
+! !     ********************
+!       saveGradients = controlVariables % logicalValueForKey("save gradients with solution")
+!       FaceComputeQdot = controlVariables % containsKey("acoustic analogy")
 
-      facesList      = IntegerDataLinkedList_t(.FALSE.)
-      elementList    = IntegerDataLinkedList_t(.FALSE.)
-      zoneList = IntegerDataLinkedList_t(.FALSE.)
-      analyticalJac  = self % storage % anJacobian
+!       facesList      = IntegerDataLinkedList_t(.FALSE.)
+!       elementList    = IntegerDataLinkedList_t(.FALSE.)
+!       zoneList = IntegerDataLinkedList_t(.FALSE.)
+!       analyticalJac  = self % storage % anJacobian
 
-!     *********************************************
-!     Adapt individual elements (geometry excluded)
-!     *********************************************
-!$omp parallel do schedule(runtime) private(fID, e)
-      do eID=1, self % no_of_elements
-         e => self % elements(eID)   ! Associate fails(!) here
-         if ( all( e % Nxyz == NNew(:,eID)) ) then
-            cycle
-         else
-            call e % pAdapt ( NNew(:,eID), self % nodeType, saveGradients, self % storage % prevSol_num )
-!$omp critical
-            self % Nx(eID) = NNew(1,eID)
-            self % Ny(eID) = NNew(2,eID)
-            self % Nz(eID) = NNew(3,eID)
-            call elementList % add (eID)
-            do fID=1, 6
-               call facesList   % add (e % faceIDs(fID))
-               if (self % faces(e % faceIDs(fID)) % FaceType  /= HMESH_BOUNDARY) then
-                  call elementList % add ( mpi_partition % global2localeID (e % Connection(fID) % globID) )
-               end if
-            end do
-!$omp end critical
+! !     *********************************************
+! !     Adapt individual elements (geometry excluded)
+! !     *********************************************
+! !$omp parallel do schedule(runtime) private(fID, e)
+!       do eID=1, self % no_of_elements
+!          e => self % elements(eID)   ! Associate fails(!) here
+!          if ( all( e % Nxyz == NNew(:,eID)) ) then
+!             cycle
+!          else
+!             call e % pAdapt ( NNew(:,eID), self % nodeType, saveGradients, self % storage % prevSol_num )
+! !$omp critical
+!             self % Nx(eID) = NNew(1,eID)
+!             self % Ny(eID) = NNew(2,eID)
+!             self % Nz(eID) = NNew(3,eID)
+!             call elementList % add (eID)
+!             do fID=1, 6
+!                call facesList   % add (e % faceIDs(fID))
+!                if (self % faces(e % faceIDs(fID)) % FaceType  /= HMESH_BOUNDARY) then
+!                   call elementList % add ( mpi_partition % global2localeID (e % Connection(fID) % globID) )
+!                end if
+!             end do
+! !$omp end critical
 
-         end if
-!~         end associate
-      end do
-!$omp end parallel do
+!          end if
+! !~         end associate
+!       end do
+! !$omp end parallel do
 
-      call facesList % ExportToArray(facesArray, .TRUE.)
+!       call facesList % ExportToArray(facesArray, .TRUE.)
 
-!     *************************
-!     Adapt corresponding faces
-!     *************************
+! !     *************************
+! !     Adapt corresponding faces
+! !     *************************
 
-!     Destruct faces storage
-!     ----------------------
-!$omp parallel do schedule(runtime)
-      do fID=1, size(facesArray)
-         call self % faces( facesArray(fID) ) % storage % destruct
-      end do
-!$omp end parallel do
+! !     Destruct faces storage
+! !     ----------------------
+! !$omp parallel do schedule(runtime)
+!       do fID=1, size(facesArray)
+!          call self % faces( facesArray(fID) ) % storage % destruct
+!       end do
+! !$omp end parallel do
 
-!     Set connectivities
-!     ------------------
-      call self % SetConnectivitiesAndLinkFaces (self % nodeType, facesArray)
+! !     Set connectivities
+! !     ------------------
+!       call self % SetConnectivitiesAndLinkFaces (self % nodeType, facesArray)
 
-!     Construct faces storage
-!     -----------------------
-!$omp parallel do private(f) schedule(runtime)
-      do fID=1, size(facesArray)
-         f => self % faces( facesArray(fID) )  ! associate fails here in intel compilers
-         call f % storage(1) % Construct(NDIM, f % Nf, f % NelLeft , computeGradients, analyticalJac, FaceComputeQdot)
-         call f % storage(2) % Construct(NDIM, f % Nf, f % NelRight, computeGradients, analyticalJac, FaceComputeQdot)
-      end do
-!$omp end parallel do
+! !     Construct faces storage
+! !     -----------------------
+! !$omp parallel do private(f) schedule(runtime)
+!       do fID=1, size(facesArray)
+!          f => self % faces( facesArray(fID) )  ! associate fails here in intel compilers
+!          call f % storage(1) % Construct(NDIM, f % Nf, f % NelLeft , computeGradients, analyticalJac, FaceComputeQdot)
+!          call f % storage(2) % Construct(NDIM, f % Nf, f % NelRight, computeGradients, analyticalJac, FaceComputeQdot)
+!       end do
+! !$omp end parallel do
 
-!     ********************
-!     Reconstruct geometry
-!     ********************
+! !     ********************
+! !     Reconstruct geometry
+! !     ********************
 
-      !* 1. Adapted elements
-      !* 2. Surrounding faces of adapted elements
-      !* 3. Neighbor elements of adapted elements whose intermediate face's geometry was adapted
-      !* 4. Faces and elements that share a boundary with a reconstructed face (3D non-conforming representations)
+!       !* 1. Adapted elements
+!       !* 2. Surrounding faces of adapted elements
+!       !* 3. Neighbor elements of adapted elements whose intermediate face's geometry was adapted
+!       !* 4. Faces and elements that share a boundary with a reconstructed face (3D non-conforming representations)
 
 
-      if (self % anisotropic .and. (.not. self % meshIs2D) ) then
+!       if (self % anisotropic .and. (.not. self % meshIs2D) ) then
 
-!        Check if any of the faces belongs to a boundary
-!        -----------------------------------------------
-         do fID=1, size(facesArray)
-            associate (f => self % faces( facesArray(fID) ) )
-            if ( f % FaceType == HMESH_BOUNDARY ) then
-               call zoneList % add (f % zone)
-            end if
-            end associate
-         end do
+! !        Check if any of the faces belongs to a boundary
+! !        -----------------------------------------------
+!          do fID=1, size(facesArray)
+!             associate (f => self % faces( facesArray(fID) ) )
+!             if ( f % FaceType == HMESH_BOUNDARY ) then
+!                call zoneList % add (f % zone)
+!             end if
+!             end associate
+!          end do
 
-!        Add the corresponding faces and elements
-!        ----------------------------------------
-         call zoneList % ExportToArray (zoneArray)
+! !        Add the corresponding faces and elements
+! !        ----------------------------------------
+!          call zoneList % ExportToArray (zoneArray)
 
-         do zoneID=1, size(zoneArray)
-            zone => self % zones( zoneArray(zoneID) )    ! Compiler bug(?): If zone was implemented as associate, gfortran would not compile
-            do fID=1, zone % no_of_faces
-               call facesList   % add ( zone % faces(fID) )
-               call elementList % add ( self % faces(zone % faces(fID)) % elementIDs(1) )
-            end do
-         end do
-         deallocate (zoneArray   )
-      end if
+!          do zoneID=1, size(zoneArray)
+!             zone => self % zones( zoneArray(zoneID) )    ! Compiler bug(?): If zone was implemented as associate, gfortran would not compile
+!             do fID=1, zone % no_of_faces
+!                call facesList   % add ( zone % faces(fID) )
+!                call elementList % add ( self % faces(zone % faces(fID)) % elementIDs(1) )
+!             end do
+!          end do
+!          deallocate (zoneArray   )
+!       end if
 
-      deallocate ( facesArray )
+!       deallocate ( facesArray )
 
-      call facesList   % ExportToArray(facesArray  , .TRUE.)
-      call elementList % ExportToArray(elementArray, .TRUE.)
+!       call facesList   % ExportToArray(facesArray  , .TRUE.)
+!       call elementList % ExportToArray(elementArray, .TRUE.)
 
-!     Destruct old
-!     ------------
-      do eID=1, size (elementArray)
-         call self % elements (elementArray(eID)) % geom % destruct
-      end do
-      do fID=1, size (facesArray)
-         call self % faces (facesArray(fID)) % geom % destruct
-      end do
+! !     Destruct old
+! !     ------------
+!       do eID=1, size (elementArray)
+!          call self % elements (elementArray(eID)) % geom % destruct
+!       end do
+!       do fID=1, size (facesArray)
+!          call self % faces (facesArray(fID)) % geom % destruct
+!       end do
 
-      call self % ConstructGeometry(facesArray, elementArray)
+!       call self % ConstructGeometry(facesArray, elementArray)
 
-#if defined(NAVIERSTOKES)
-      call self % ComputeWallDistances(facesArray, elementArray)
-#endif
+! #if defined(NAVIERSTOKES)
+!       call self % ComputeWallDistances(facesArray, elementArray)
+! #endif
 
-!     *********
-!     Finish up
-!     *********
-      call self % PrepareForIO
+! !     *********
+! !     Finish up
+! !     *********
+!       call self % PrepareForIO
 
-      call facesList    % destruct
-      call elementList  % destruct
-      call zoneList     % destruct
-      nullify (zone)
-      nullify (e)
-      nullify (f)
-      deallocate (facesArray  )
-      deallocate (elementArray)
+!       call facesList    % destruct
+!       call elementList  % destruct
+!       call zoneList     % destruct
+!       nullify (zone)
+!       nullify (e)
+!       nullify (f)
+!       deallocate (facesArray  )
+!       deallocate (elementArray)
 
-   end subroutine HexMesh_pAdapt
+!    end subroutine HexMesh_pAdapt
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !

--- a/Solver/src/libs/mesh/StorageClass.f90
+++ b/Solver/src/libs/mesh/StorageClass.f90
@@ -32,12 +32,12 @@ module StorageClass
 !  Class for pointing to previous solutions in an element
 !  ******************************************************
    type ElementPrevSol_t
-      real(kind=RP), dimension(:,:,:,:),  pointer, contiguous     :: Q ! Pointers to the appropriate storage (NS or CH)
+      real(kind=RP), dimension(:,:,:,:), pointer, contiguous :: Q ! Pointers to the appropriate storage (NS or CH)
 #ifdef FLOW
-      real(kind=RP), dimension(:,:,:,:),  allocatable     :: QNS
+      real(kind=RP), dimension(:,:,:,:), pointer, contiguous :: QNS
 #endif
 #ifdef CAHNHILLIARD
-      real(kind=RP), dimension(:,:,:,:),  allocatable     :: c
+      real(kind=RP), dimension(:,:,:,:), pointer, contiguous :: c
 #endif
    end type ElementPrevSol_t
 
@@ -68,9 +68,9 @@ module StorageClass
       type(ElementPrevSol_t),  allocatable :: PrevQ(:)           ! Previous solution
       type(RKStep_t),          allocatable :: RKSteps(:)         ! Runge-Kutta stages
 #ifdef FLOW
-      real(kind=RP),           allocatable :: QNS(:,:,:,:)         ! NSE State vector
+      real(kind=RP), pointer,  contiguous  :: QNS(:,:,:,:)         ! NSE State vector
+      real(kind=RP), pointer,  contiguous  :: QDotNS(:,:,:,:)      ! NSE State vector time derivative
       real(kind=RP),           allocatable :: rho(:,:,:)           ! Temporal storage for the density
-      real(kind=RP), private,  allocatable :: QDotNS(:,:,:,:)      ! NSE State vector time derivative
       real(kind=RP), private,  allocatable :: U_xNS(:,:,:,:)       ! NSE x-gradients
       real(kind=RP), private,  allocatable :: U_yNS(:,:,:,:)       ! NSE y-gradients
       real(kind=RP), private,  allocatable :: U_zNS(:,:,:,:)       ! NSE z-gradients
@@ -88,28 +88,26 @@ module StorageClass
       real(kind=RP),           allocatable :: mu_SA(:,:,:,:)         ! EddyViscocityVector, EddyetaVector
 #endif
 #ifdef CAHNHILLIARD
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: c     ! CHE concentration
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: cDot  ! CHE concentration time derivative
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: c_x   ! CHE concentration x-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: c_y   ! CHE concentration y-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: c_z   ! CHE concentration z-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: mu    ! CHE chemical potential
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: mu_x  ! CHE chemical potential x-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: mu_y  ! CHE chemical potential y-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: mu_z  ! CHE chemical potential z-gradient
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: v     ! CHE flow field velocity
-      real(kind=RP), dimension(:,:,:,:),   allocatable :: G_CH  ! CHE auxiliary storage
+      real(kind=RP), pointer, contiguous  :: c(:,:,:,:)     ! CHE concentration
+      real(kind=RP), pointer, contiguous  :: cDot(:,:,:,:)  ! CHE concentration time derivative
+      real(kind=RP),          allocatable :: c_x(:,:,:,:)   ! CHE concentration x-gradient
+      real(kind=RP),          allocatable :: c_y(:,:,:,:)   ! CHE concentration y-gradient
+      real(kind=RP),          allocatable :: c_z(:,:,:,:)   ! CHE concentration z-gradient
+      real(kind=RP),          allocatable :: mu(:,:,:,:)    ! CHE chemical potential
+      real(kind=RP),          allocatable :: mu_x(:,:,:,:)  ! CHE chemical potential x-gradient
+      real(kind=RP),          allocatable :: mu_y(:,:,:,:)  ! CHE chemical potential y-gradient
+      real(kind=RP),          allocatable :: mu_z(:,:,:,:)  ! CHE chemical potential z-gradient
+      real(kind=RP),          allocatable :: v(:,:,:,:)     ! CHE flow field velocity
+      real(kind=RP),          allocatable :: G_CH(:,:,:,:)  ! CHE auxiliary storage
 #endif
       contains
          procedure   :: Assign              => ElementStorage_Assign
          generic     :: assignment(=)       => Assign
-         procedure   :: Construct           => ElementStorage_Construct
-         procedure   :: Destruct            => ElementStorage_Destruct
          procedure   :: InterpolateSolution => ElementStorage_InterpolateSolution
          procedure   :: PointStorage        => ElementStorage_PointStorage
          procedure   :: constructAnJac      => ElementStorage_ConstructAnJac
 #ifdef FLOW
-         procedure   :: SetStorageToNS    => ElementStorage_SetStorageToNS
+         procedure   :: SetStorageToNS      => ElementStorage_SetStorageToNS
 #endif
 #ifdef CAHNHILLIARD
          procedure   :: SetStorageToCH_c  => ElementStorage_SetStorageToCH_c
@@ -134,22 +132,18 @@ module StorageClass
       real(kind=RP),                 pointer     :: QDot(:)
       real(kind=RP),                 pointer     :: PrevQ(:,:)
 #ifdef FLOW
-      real(kind=RP), dimension(:)  , allocatable :: QdotNS
       real(kind=RP), dimension(:)  , allocatable :: QNS
+      real(kind=RP), dimension(:)  , allocatable :: QdotNS
       real(kind=RP), dimension(:,:), allocatable :: PrevQNS ! Previous solution(s) in the whole domain
 #endif
 #ifdef CAHNHILLIARD
-      real(kind=RP), dimension(:)  , allocatable :: cDot
       real(kind=RP), dimension(:)  , allocatable :: c
+      real(kind=RP), dimension(:)  , allocatable :: cDot
       real(kind=RP), dimension(:,:), allocatable :: Prevc(:,:)
 #endif
       contains
          procedure :: construct        => SolutionStorage_Construct
-         procedure :: local2GlobalQ    => SolutionStorage_local2GlobalQ
-         procedure :: local2GlobalQdot => SolutionStorage_local2GlobalQdot
          procedure :: SetGlobalPrevQ   => SolutionStorage_SetGlobalPrevQ
-         procedure :: global2LocalQ    => SolutionStorage_global2LocalQ
-         procedure :: global2LocalQdot => SolutionStorage_global2LocalQdot
          procedure :: Destruct         => SolutionStorage_Destruct
          procedure :: SignalAdaptation => SolutionStorage_SignalAdaptation
          procedure :: PointStorage     => SolutionStorage_PointStorage
@@ -181,7 +175,7 @@ module StorageClass
       real(kind=RP), dimension(:,:),       allocatable :: rho
       real(kind=RP), dimension(:,:,:),     allocatable :: mu_NS
       real(kind=RP), dimension(:,:),       allocatable :: u_tau_NS
-      real(kind=RP), dimension(:,:),     allocatable :: wallNodeDistance ! for BC walls, distance to the first fluid node
+      real(kind=RP), dimension(:,:),       allocatable :: wallNodeDistance ! for BC walls, distance to the first fluid node
 !
 !     Inviscid Jacobians
 !     ------------------
@@ -283,12 +277,13 @@ module StorageClass
          class(SolutionStorage_t), target, intent(inout) :: self
          integer                 , intent(in)    :: NDOF
          integer, dimension(:)   , intent(in)    :: Nx, Ny, Nz
-         logical                 , intent(in)    :: computeGradients                   !<  Compute gradients?
-         logical                 , intent(in)    :: analyticalJac                      !<  Create storage for analytical Jacobian?
+         logical                 , intent(in)    :: computeGradients  !<  Compute gradients?
+         logical                 , intent(in)    :: analyticalJac     !<  Create storage for analytical Jacobian?
          integer, optional       , intent(in)    :: prevSol_num
          integer, optional       , intent(in)    :: RKSteps_num
          !-local-variables---------------------------------------
          integer :: k, eID, num_of_elems
+         integer :: offset
          !-------------------------------------------------------
 
          self % NDOF = NDOF
@@ -298,14 +293,14 @@ module StorageClass
             self % prevSol_num = prevSol_num
             if ( prevSol_num > 0 ) then
                allocate ( self % prevSol_index(prevSol_num) )
-               self % prevSol_index = (/ (k, k=1, prevSol_num) /)
+               self % prevSol_index = [ (k, k=1, prevSol_num) ]
 #ifdef FLOW
                allocate ( self % PrevQNS(NCONS*NDOF, prevSol_num) )
-               self % PrevQ    => self % PrevQNS
+               self % PrevQ => self % PrevQNS
 #endif
 #ifdef CAHNHILLIARD
                allocate ( self % Prevc  (NCOMP*NDOF, prevSol_num) )
-               self % PrevQ    => self % Prevc
+               self % PrevQ => self % Prevc
 #endif
             end if
             if ( prevSol_num >= 0 ) then
@@ -316,155 +311,32 @@ module StorageClass
                self % Qdot => self % QdotNS
 #endif
 #ifdef CAHNHILLIARD
-               allocate ( self % c     (NCOMP*NDOF) )
-               allocate ( self % cDot  (NCOMP*NDOF) )
+               allocate ( self % c   (NCOMP*NDOF) )
+               allocate ( self % cDot(NCOMP*NDOF) )
                self % Q    => self % c
                self % Qdot => self % cDot
 #endif
             end if
          end if
 
+         offset = 0
          num_of_elems = size(Nx)
-         allocate (self % elements(num_of_elems) )
+         allocate ( self % elements(num_of_elems) )
 
-         if ( present(RKSteps_num) .and. present(prevSol_num)) then
-!$omp parallel do schedule(runtime)
-            do eID=1,  num_of_elems
-               call self % elements(eID) % construct( Nx(eID), Ny(eID), Nz(eID), computeGradients, analyticalJac, prevSol_num, RKSteps_num)
-            end do
-!$omp end parallel do
-         elseif ( present(prevSol_num) ) then
-!$omp parallel do schedule(runtime)
-            do eID=1,  num_of_elems
-               call self % elements(eID) % construct( Nx(eID), Ny(eID), Nz(eID), computeGradients, analyticalJac, prevSol_num, 0)
-            end do
-!$omp end parallel do
-         elseif ( present(RKSteps_num) ) then
-!$omp parallel do schedule(runtime)
-            do eID=1,  num_of_elems
-               call self % elements(eID) % construct( Nx(eID), Ny(eID), Nz(eID), computeGradients, analyticalJac, -1, RKSteps_num)
-            end do
-!$omp end parallel do
-         else
-!$omp parallel do schedule(runtime)
-            do eID=1,  num_of_elems
-               call self % elements(eID) % construct( Nx(eID), Ny(eID), Nz(eID), computeGradients, analyticalJac,-1,0)
-            end do
-!$omp end parallel do
-
-
-         end if
+         do eID = 1, num_of_elems
+            if ( present(RKSteps_num) .and. present(prevSol_num)) then
+               call construct_ElementStorage(self % elements(eID), Nx(eID), Ny(eID), Nz(eID), offset, self, computeGradients, analyticalJac, prevSol_num, RKSteps_num)
+            elseif ( present(prevSol_num) ) then
+               call construct_ElementStorage(self % elements(eID), Nx(eID), Ny(eID), Nz(eID), offset, self, computeGradients, analyticalJac, prevSol_num, 0)
+            elseif ( present(RKSteps_num) ) then
+               call construct_ElementStorage(self % elements(eID), Nx(eID), Ny(eID), Nz(eID), offset, self, computeGradients, analyticalJac, -1, RKSteps_num)
+            else
+               call construct_ElementStorage(self % elements(eID), Nx(eID), Ny(eID), Nz(eID), offset, self, computeGradients, analyticalJac, -1, 0)
+            end if
+            offset = offset + self % elements(eID) % NDOF
+         end do
 
       end subroutine SolutionStorage_Construct
-!
-!///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-!
-!     --------------------------------------------
-!     Load the local solutions into a global array
-!     --------------------------------------------
-      pure subroutine SolutionStorage_local2GlobalQ(self, NDOF)
-         implicit none
-         !----------------------------------------------
-         class(SolutionStorage_t), target, intent(inout) :: self
-         integer                 , intent(in)    :: NDOF
-         !----------------------------------------------
-         integer :: firstIdx, lastIdx, eID
-         !----------------------------------------------
-
-!        Allocate storage
-!        ****************
-#ifdef FLOW
-         if (self % AdaptedQ .or. (.not. allocated(self % QNS) ) ) then
-            self % NDOF = NDOF
-            safedeallocate (self % QNS   )
-            allocate ( self % QNS   (NCONS*NDOF) )
-
-            self % AdaptedQ = .FALSE.
-         end if
-#endif
-#ifdef CAHNHILLIARD
-         if (self % AdaptedQ .or. (.not. allocated(self % c) ) ) then
-            self % NDOF = NDOF
-            safedeallocate (self % c)
-            allocate ( self % c(NCOMP*NDOF) )
-
-            self % AdaptedQ = .FALSE.
-         end if
-#endif
-!
-!        Load solution
-!        *************
-
-#ifdef FLOW
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            lastIdx = firstIdx + self % elements(eID) % NDOF * NCONS
-            self % QNS (firstIdx : lastIdx - 1) = reshape ( self % elements(eID) % QNS , (/ self % elements(eID) % NDOF *NCONS /) )
-            firstIdx = lastIdx
-         end do
-#endif
-#ifdef CAHNHILLIARD
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            lastIdx = firstIdx + self % elements(eID) % NDOF * NCOMP
-            self % c (firstIdx : lastIdx - 1) = reshape ( self % elements(eID) % c , (/ self % elements(eID) % NDOF *NCOMP /) )
-            firstIdx = lastIdx
-         end do
-#endif
-
-      end subroutine SolutionStorage_local2GlobalQ
-!
-!///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-!
-!     ---------------------------------------
-!     Load the local Qdot into a global array
-!     ---------------------------------------
-      pure subroutine SolutionStorage_local2GlobalQdot(self, NDOF)
-         implicit none
-         !----------------------------------------------
-         class(SolutionStorage_t), target, intent(inout) :: self
-         integer                 , intent(in)    :: NDOF
-         !----------------------------------------------
-         integer :: firstIdx, lastIdx, eID
-         !----------------------------------------------
-
-         self % NDOF = NDOF
-
-#ifdef FLOW
-         if (self % AdaptedQdot .or. (.not. allocated(self % QdotNS) ) ) then
-            safedeallocate (self % QdotNS)
-            allocate ( self % QdotNS(NCONS*NDOF) )
-         end if
-#endif
-#ifdef CAHNHILLIARD
-         if (self % AdaptedQdot .or. (.not. allocated(self % cDot) ) ) then
-            safedeallocate ( self % cDot )
-            allocate ( self % cDot(NCOMP*NDOF) )
-         end if
-#endif
-         self % AdaptedQdot = .FALSE.
-
-!
-!        Load solution
-!        *************
-
-#ifdef FLOW
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            lastIdx = firstIdx + self % elements(eID) % NDOF * NCONS
-            self % QdotNS (firstIdx : lastIdx - 1) = reshape ( self % elements(eID) % QdotNS , (/ self % elements(eID) % NDOF * NCONS/) )
-            firstIdx = lastIdx
-         end do
-#endif
-#ifdef CAHNHILLIARD
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            lastIdx = firstIdx + self % elements(eID) % NDOF * NCOMP
-            self % cDot (firstIdx : lastIdx - 1) = reshape ( self % elements(eID) % cDot , (/ self % elements(eID) % NDOF * NCOMP /) )
-            firstIdx = lastIdx
-         end do
-#endif
-      end subroutine SolutionStorage_local2GlobalQdot
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
@@ -489,6 +361,7 @@ module StorageClass
             safedeallocate (self % PrevQNS)
             allocate ( self % PrevQNS (NCONS * self % NDOF, self % prevSol_num) )
 
+            self % PrevQ => self % PrevQNS
             self % AdaptedPrevQ = .FALSE.
 
             ! TODO: Adapt previous solutions...
@@ -499,6 +372,7 @@ module StorageClass
             safedeallocate (self % PrevC)
             allocate ( self % PrevC(NCOMP * self % NDOF, self % prevSol_num) )
 
+            self % PrevQ => self % Prevc
             self % AdaptedPrevQ = .FALSE.
 
             ! TODO: Adapt previous solutions...
@@ -521,73 +395,6 @@ module StorageClass
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
-      pure subroutine SolutionStorage_global2LocalQ(self)
-         implicit none
-         !----------------------------------------------
-         class(SolutionStorage_t), target, intent(inout)    :: self
-         !----------------------------------------------
-         integer :: firstIdx, lastIdx, eID
-         integer :: nEqn
-         !----------------------------------------------
-
-         ! Temporary only checking first element!
-         select case (self % elements(1) % currentlyLoaded)
-            case (NS,NSSA)
-#ifdef FLOW
-               nEqn = NCONS
-#endif
-            case (C,MU)
-#ifdef CAHNHILLIARD
-               nEqn = NCOMP
-#endif
-         end select
-
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            associate ( N => self % elements(eID) % Nxyz )
-            lastIdx = firstIdx + self % elements(eID) % NDOF * nEqn
-            self % elements(eID) % Q(1:nEqn,0:N(1),0:N(2),0:N(3)) = reshape ( self % Q (firstIdx:lastIdx-1) , (/ nEqn, N(1)+1, N(2)+1, N(3)+1/) )
-            firstIdx = lastIdx
-            end associate
-         end do
-
-      end subroutine SolutionStorage_global2LocalQ
-!
-!///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-!
-      pure subroutine SolutionStorage_global2LocalQdot(self)
-         implicit none
-         !----------------------------------------------
-         class(SolutionStorage_t), target, intent(inout) :: self
-         !----------------------------------------------
-         integer :: firstIdx, lastIdx, eID
-         integer :: nEqn
-         !----------------------------------------------
-
-         ! Temporary only checking first element!
-         select case (self % elements(1) % currentlyLoaded)
-            case (NS,NSSA)
-#ifdef FLOW
-               nEqn = NCONS
-#endif
-            case (C,MU)
-#ifdef CAHNHILLIARD
-               nEqn = NCOMP
-#endif
-         end select
-
-         firstIdx = 1
-         do eID=1, size(self % elements)
-            associate ( N => self % elements(eID) % Nxyz )
-            lastIdx = firstIdx + self % elements(eID) % NDOF * nEqn
-            self % elements(eID) % Qdot(1:nEqn,0:N(1),0:N(2),0:N(3)) = reshape ( self % Qdot (firstIdx:lastIdx-1) , (/ nEqn, N(1)+1, N(2)+1, N(3)+1/) )
-            firstIdx = lastIdx
-            end associate
-         end do
-
-      end subroutine SolutionStorage_global2LocalQdot
-!
-!/////////////////////////////////////////////////
 !
       pure subroutine SolutionStorage_SignalAdaptation(self)
          implicit none
@@ -645,6 +452,11 @@ module StorageClass
          self % AdaptedPrevQ = .FALSE.
          self % anJacobian   = .FALSE.
 
+         if ( allocated(self % elements) ) then
+            call destruct_ElementStorage(self % elements)
+            deallocate (self % elements)
+         end if
+
          safedeallocate(self % prevSol_index)
 
 #ifdef FLOW
@@ -657,11 +469,6 @@ module StorageClass
          safedeallocate(self % cDot)
          safedeallocate(self % PrevC)
 #endif
-
-         if ( allocated(self % elements) ) then
-            call self % elements % destruct
-            deallocate (self % elements)
-         end if
 
       end subroutine SolutionStorage_Destruct
 !
@@ -677,6 +484,7 @@ module StorageClass
          !-local-variables------------------------------
          integer :: num_of_elems
          integer :: eID
+         integer :: offset
          !----------------------------------------------
 !
 !        Copy the storage
@@ -692,44 +500,55 @@ module StorageClass
 
 
 
-         num_of_elems = size(from % elements)
-         allocate ( to % elements (num_of_elems) )
-!$omp parallel do schedule(runtime)
-         do eID=1, num_of_elems
-            to % elements(eID) = from % elements(eID)
-         end do
-!$omp end parallel do
-
          if ( to % prevSol_num > 0 ) then
             allocate ( to % prevSol_index ( size(from % prevSol_index) ) )
-            to % prevSol_index=  from % prevSol_index
+            to % prevSol_index = from % prevSol_index
 #ifdef FLOW
             allocate ( to % PrevQNS ( size(from % PrevQNS,1),size(from % PrevQNS,2) ) )
-            to % PrevQNS      =  from % PrevQNS
+            to % PrevQNS = from % PrevQNS
 #endif
 #ifdef CAHNHILLIARD
             allocate ( to % Prevc ( size(from % Prevc,1),size(from % Prevc,2) ) )
-            to % Prevc        =  from % Prevc
+            to % Prevc = from % Prevc
 #endif
          end if
 
          if ( to % prevSol_num >= 0 ) then
 #ifdef FLOW
             allocate ( to % QdotNS ( size(from % QdotNS) ) )
-            to % QdotNS       =  from % QdotNS
+            to % QdotNS = from % QdotNS
 
             allocate ( to % QNS ( size(from % QNS) ) )
-            to % QNS          =  from % QNS
+            to % QNS = from % QNS
 #endif
 #ifdef CAHNHILLIARD
             allocate ( to % cDot ( size(from % cDot) ) )
-            to % cDot         =  from % cDot
+            to % cDot = from % cDot
 
             allocate ( to % c ( size(from % c) ) )
-            to % c            =  from % c
+            to % c = from % c
 #endif
          end if
 
+         offset = 0
+         num_of_elems = size(from % elements)
+         allocate ( to % elements (num_of_elems) )
+
+         do eID=1, num_of_elems
+            call destruct_ElementStorage(to % elements(eID))
+            call construct_ElementStorage(to % elements(eID), &
+                                          from % elements(eID) % Nxyz(1), &
+                                          from % elements(eID) % Nxyz(2), &
+                                          from % elements(eID) % Nxyz(3), &
+                                          offset, &
+                                          to, &
+                                          from % elements(eID) % computeGradients, & ! TODO: Fix this: it is not being used!!
+                                          from % elements(eID) % anJacobian, &
+                                          from % elements(eID) % prevSol_num, &
+                                          from % elements(eID) % RKSteps_num)
+            to % elements(eID) = from % elements(eID)
+            offset = offset + from % elements(eID) % NDOF
+         end do
 !
 !        Point the storage
 !        -----------------
@@ -744,16 +563,19 @@ module StorageClass
 !
 !///////////////////////////////////////////////////////////////////////////////////////////
 !
-      elemental subroutine ElementStorage_Construct(self, Nx, Ny, Nz, computeGradients, analyticalJac, prevSol_num, RKSteps_num)
+       subroutine construct_ElementStorage(self, Nx, Ny, Nz, offset, global_storage, computeGradients, analyticalJac, prevSol_num, RKSteps_num)
          implicit none
          !------------------------------------------------------------
-         class(ElementStorage_t), intent(inout) :: self                               !<> Storage to be constructed
-         integer                , intent(in)    :: Nx, Ny, Nz                         !<  Polynomial orders in every direction
-         logical                , intent(in)    :: computeGradients                   !<  Compute gradients?
-         logical                , intent(in)    :: analyticalJac                      !<  Analytical Jacobian specific storage(?)
-         integer                , intent(in)    :: prevSol_num
-         integer                , intent(in)    :: RKSteps_num
+         class(ElementStorage_t), intent(inout)      :: self              !<> Storage to be constructed
+         integer                , intent(in)         :: Nx, Ny, Nz        !<  Polynomial orders in every direction
+         integer                , intent(in)         :: offset            !<  Offset in global storage
+         type(SolutionStorage_t), intent(in), target :: global_storage
+         logical                , intent(in)         :: computeGradients  !<  Compute gradients?
+         logical                , intent(in)         :: analyticalJac     !<  Analytical Jacobian specific storage(?)
+         integer                , intent(in)         :: prevSol_num
+         integer                , intent(in)         :: RKSteps_num
          !------------------------------------------------------------
+         integer :: i1, i2
          integer :: k
          !------------------------------------------------------------
 
@@ -774,14 +596,16 @@ module StorageClass
 !        ----------------
 !
 #ifdef FLOW
-         allocate ( self % QNS   (1:NCONS,0:Nx,0:Ny,0:Nz) )
-         allocate ( self % QdotNS(1:NCONS,0:Nx,0:Ny,0:Nz) )
+         i1 = offset * NCONS + 1
+         i2 = offset * NCONS + self % NDOF * NCONS
+         self % QNS(1:NCONS,0:Nx,0:Ny,0:Nz)    => global_storage % QNS(i1:i2)
+         self % QdotNS(1:NCONS,0:Nx,0:Ny,0:Nz) => global_storage % QdotNS(i1:i2)
          allocate ( self % rho   (0:Nx,0:Ny,0:Nz) )
          ! Previous solution
          if ( prevSol_num /= 0 ) then
             allocate ( self % PrevQ(prevSol_num) )
             do k=1, prevSol_num
-               allocate ( self % PrevQ(k) % QNS(1:NCONS,0:Nx,0:Ny,0:Nz) )
+               self % PrevQ(k) % QNS(1:NCONS,0:Nx,0:Ny,0:Nz) => global_storage % PrevQNS(i1:i2,k)
             end do
          end if
 
@@ -808,8 +632,10 @@ module StorageClass
          call self % SetStorageToNS
 #endif
 #ifdef CAHNHILLIARD
-         allocate ( self % c   (1:NCOMP,0:Nx,0:Ny,0:Nz) )
-         allocate ( self % cDot(1:NCOMP,0:Nx,0:Ny,0:Nz) )
+         i1 = offset * NCOMP + 1
+         i2 = offset * NCOMP + self % NDOF * NCOMP
+         self % c(1:NCOMP,0:Nx,0:Ny,0:Nz)    => global_storage % c(i1:i1)
+         self % cDot(1:NCOMP,0:Nx,0:Ny,0:Nz) => global_storage % cDot(i1:i1)
          ! Previous solution
          if ( prevSol_num /= 0 ) then
             if ( .not. allocated(self % PrevQ)) then
@@ -818,7 +644,7 @@ module StorageClass
          end if
 
          do k=1, prevSol_num
-            allocate ( self % PrevQ(k) % c(1:NCOMP,0:Nx,0:Ny,0:Nz) )
+            self % PrevQ(k) % c(1:NCOMP,0:Nx,0:Ny,0:Nz) => global_storage % Prevc(i1:i2,k)
          end do
 
          allocate(self % c_x (NCOMP, 0:Nx, 0:Ny, 0:Nz))
@@ -885,7 +711,7 @@ module StorageClass
          self % prev_sensor = 1.0_RP
          self % sensor = 1.0_RP  ! Activate the sensor by default (first time-step when SC is on)
 
-      end subroutine ElementStorage_Construct
+      end subroutine construct_ElementStorage
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
@@ -922,14 +748,6 @@ module StorageClass
          class(ElementStorage_t), intent(inout) :: to
          type(ElementStorage_t),  intent(in)    :: from
 
-         call to % destruct
-         call to % construct (from % Nxyz(1), &
-                              from % Nxyz(2), &
-                              from % Nxyz(3), &
-                              from % computeGradients, & ! TODO: Fix this: it is not being used!!
-                              from % anJacobian, &
-                              from % prevSol_num, &
-                              from % RKSteps_num )
 !
 !        Copy the storage
 !        ----------------
@@ -944,12 +762,12 @@ module StorageClass
          to % sensor       = from % sensor
 
 #ifdef FLOW
-         to % QNS    = from % QNS
+         to % QNS = from % QNS
 
          if (to % computeGradients) then
-            to % U_xNS  = from % U_xNS
-            to % U_yNS  = from % U_yNS
-            to % U_zNS  = from % U_zNS
+            to % U_xNS = from % U_xNS
+            to % U_yNS = from % U_yNS
+            to % U_zNS = from % U_zNS
          end if
          to % QDotNS = from % QDotNS
          to % G_NS   = from % G_NS
@@ -960,9 +778,9 @@ module StorageClass
          to % S_SA   = from % S_SA
 #endif
 
-         to % mu_NS     = from % mu_NS
-         to % mu_turb_NS     = from % mu_turb_NS
-         to % stats     = from % stats
+         to % mu_NS      = from % mu_NS
+         to % mu_turb_NS = from % mu_turb_NS
+         to % stats      = from % stats
 
          if (to % anJacobian) then
             to % dF_dgradQ = from % dF_dgradQ
@@ -1015,7 +833,7 @@ module StorageClass
 !
 !///////////////////////////////////////////////////////////////////////////////////////////
 !
-      elemental subroutine ElementStorage_Destruct(self)
+      elemental subroutine destruct_ElementStorage(self)
          implicit none
          class(ElementStorage_t), intent(inout) :: self
          integer                 :: num_prevSol, k
@@ -1030,13 +848,14 @@ module StorageClass
          self % U_z => NULL()
 
 #ifdef FLOW
-         safedeallocate(self % QNS)
-         safedeallocate(self % QDotNS)
+         nullify(self % QNS)
+         nullify(self % QDotNS)
 
          if ( allocated(self % PrevQ) ) then
             num_prevSol = size(self % PrevQ)
             do k=1, num_prevSol
-               safedeallocate( self % PrevQ(k) % QNS )
+               nullify(self % PrevQ(k) % Q)
+               nullify(self % PrevQ(k) % QNS)
             end do
          end if
 
@@ -1063,13 +882,14 @@ module StorageClass
 #endif
 
 #ifdef CAHNHILLIARD
-         safedeallocate(self % c)
-         safedeallocate(self % cDot)
+         nullify(self % c)
+         nullify(self % cDot)
 
          if ( allocated(self % PrevQ) ) then
             num_prevSol = size(self % PrevQ)
             do k=1, num_prevSol
-               safedeallocate( self % PrevQ(k) % c )
+               nullify(self % PrevQ(k) % Q)
+               nullify(self % PrevQ(k) % c)
             end do
          end if
 
@@ -1085,7 +905,7 @@ module StorageClass
 #endif
          safedeallocate(self % PrevQ)
 
-      end subroutine ElementStorage_Destruct
+      end subroutine destruct_ElementStorage
 #ifdef FLOW
       pure subroutine ElementStorage_SetStorageToNS(self)
 !
@@ -1108,11 +928,11 @@ module StorageClass
 #else
          self % currentlyLoaded = NSSA
 #endif
-         self % Q   (1:,0:,0:,0:) => self % QNS
+         self % Q(1:,0:,0:,0:) => self % QNS
          if (self % computeGradients) then
-            self % U_x (1:,0:,0:,0:) => self % U_xNS
-            self % U_y (1:,0:,0:,0:) => self % U_yNS
-            self % U_z (1:,0:,0:,0:) => self % U_zNS
+            self % U_x(1:,0:,0:,0:) => self % U_xNS
+            self % U_y(1:,0:,0:,0:) => self % U_yNS
+            self % U_z(1:,0:,0:,0:) => self % U_zNS
          end if
          self % QDot(1:,0:,0:,0:) => self % QDotNS
 
@@ -1314,7 +1134,7 @@ module StorageClass
          allocate( self % mu_NS     (1:3,0:Nf(1),0:Nf(2)) )
          allocate( self % u_tau_NS  (0:Nf(1),0:Nf(2)) )
          allocate( self % wallNodeDistance  (0:Nf(1),0:Nf(2)) )
-         
+
          if (analyticalJac) call self % ConstructAnJac(NDIM) ! This is actually not specific for NS
 #endif
 #ifdef CAHNHILLIARD
@@ -1448,7 +1268,7 @@ module StorageClass
          safedeallocate(self % wallNodeDistance)
          safedeallocate(self % rho )
 
-         self % anJacobian      = .FALSE.
+         self % anJacobian = .FALSE.
 
          if (self % anJacobian) then
             safedeallocate(self % dFStar_dqF)
@@ -1494,7 +1314,7 @@ module StorageClass
 #endif
 !        Get sizes
 !        ---------
-         self % Q   (1:,0:,0:)            => self % QNS
+         self % Q    (1:,0:,0:) => self % QNS
          self % fStar(1:NCONS, 0:self % Nel(1), 0:self % Nel(2)) => self % genericInterfaceFluxMemory
 
          self % genericInterfaceFluxMemory = 0.0_RP
@@ -1668,11 +1488,11 @@ module StorageClass
          implicit none
          integer, intent(out) :: off_, ns_, c_, mu_, nssa_
 
-         off_ = OFF
-         ns_  = NS
-         c_   = C
-         mu_  = MU
-         nssa_= NSSA
+         off_  = OFF
+         ns_   = NS
+         c_    = C
+         mu_   = MU
+         nssa_ = NSSA
 
       end subroutine GetStorageEquations
 

--- a/Solver/src/libs/timeintegrator/AnisFASMultigridClass.f90
+++ b/Solver/src/libs/timeintegrator/AnisFASMultigridClass.f90
@@ -439,7 +439,7 @@ module AnisFASMultigridClass
          N2trans = transpose(N2)
          
          call Stopwatch % Start("AnisFAS: child-adapt")
-         call Child_p % MGStorage(Dir) % p_sem % mesh % pAdapt (N2trans, controlVariables)
+         ! call Child_p % MGStorage(Dir) % p_sem % mesh % pAdapt (N2trans, controlVariables)
          call Stopwatch % Pause("AnisFAS: child-adapt")
          
          call Child_p % MGStorage(Dir) % p_sem % mesh % storage % PointStorage

--- a/Solver/src/libs/timeintegrator/BDFTimeIntegrator.f90
+++ b/Solver/src/libs/timeintegrator/BDFTimeIntegrator.f90
@@ -242,8 +242,6 @@ contains
       
       this % inner_dt = dt            ! first inner_dt is the outer step dt 
       time = t
-      
-      call sem % mesh % storage % local2GlobalQ(sem % NDOF)
 !
 !     ********************
 !     Sub-time-step solver
@@ -347,9 +345,6 @@ contains
       !**************************
       
 !~       if (MAXVAL(maxResidual) > sem % maxResidual) computeA = .TRUE.
-      
-      call sem % mesh % storage % global2LocalQ
-      call sem % mesh % storage % global2LocalQdot
       
    end subroutine TakeBDFStep
 !
@@ -479,9 +474,7 @@ contains
       real(kind=RP)  :: RHS(NCONS*sem % NDOF)
       !----------------------------------------------------------------
       
-      call sem % mesh % storage % global2LocalQ
       call ComputeTimeDerivative( sem % mesh, sem % particles, t, CTD_IGNORE_MODE)
-      call sem % mesh % storage % local2GlobalQdot(sem % NDOF)
       
       RHS = BDF_GetRHS(sem % mesh % storage, dt)
       

--- a/Solver/src/libs/timeintegrator/FASMultigridClass.f90
+++ b/Solver/src/libs/timeintegrator/FASMultigridClass.f90
@@ -1511,8 +1511,6 @@ module FASMultigridClass
                error stop "FASMultigrid :: IRK Smoother not ready."
             case (SGS_SMOOTHER)
 
-               call this % p_sem % mesh % storage % local2globalq (this % p_sem % mesh % storage % NDOF)
-
                do sweep = 1, SmoothSweeps
                   if (Compute_dt) call MaxTimeStep(self=this % p_sem, cfl=smoother_cfl, dcfl=smoother_dcfl, MaxDt=smoother_dt )
                   if( this% p_sem% mesh% IBM% TimePenal ) this% p_sem% mesh% IBM% penalization = dt
@@ -1522,8 +1520,6 @@ module FASMultigridClass
 
             case (ILU_SMOOTHER)
 
-               call this % p_sem % mesh % storage % local2globalq (this % p_sem % mesh % storage % NDOF)
-
                do sweep = 1, SmoothSweeps
                   if (Compute_dt) call MaxTimeStep(self=this % p_sem, cfl=smoother_cfl, dcfl=smoother_dcfl, MaxDt=smoother_dt )
                   if( this% p_sem% mesh% IBM% TimePenal ) this% p_sem% mesh% IBM% penalization = dt
@@ -1532,8 +1528,6 @@ module FASMultigridClass
                end do
 
             case (BIRK5_SMOOTHER)
-
-               call this % p_sem % mesh % storage % local2globalq (this % p_sem % mesh % storage % NDOF)
 
                do sweep = 1, SmoothSweeps
                   if (Compute_dt) call MaxTimeStep(self=this % p_sem, cfl=smoother_cfl, dcfl=smoother_dcfl, MaxDt=smoother_dt )
@@ -1587,8 +1581,6 @@ module FASMultigridClass
          if ( present(dts) ) then
             if (dts) call ComputePseudoTimeDerivative(this % p_sem % mesh, t, global_dt)
          end if
-         call this % p_sem % mesh % storage % local2globalqdot (this % p_sem % mesh % storage % NDOF)
-
 
          select type (Adense => this % A)
             type is (DenseBlockDiagMatrix_t)
@@ -1608,7 +1600,6 @@ module FASMultigridClass
          end select
 
          this % p_sem % mesh % storage % Q = this % p_sem % mesh % storage % Q - this % dQ
-         call this % p_sem % mesh % storage % global2localq
       end do ! k
 
 !$omp parallel do schedule(runtime)
@@ -1663,8 +1654,6 @@ module FASMultigridClass
          if ( present(dts) ) then
             if (dts) call ComputePseudoTimeDerivative(this % p_sem % mesh, t, global_dt)
          end if
-         call this % p_sem % mesh % storage % local2globalqdot (this % p_sem % mesh % storage % NDOF)
-
 
          select type (Acsr => this % A)
             type is (csrMat_t)
@@ -1696,7 +1685,6 @@ module FASMultigridClass
          end select
 
          this % p_sem % mesh % storage % Q = this % p_sem % mesh % storage % Q - this % dQ
-         call this % p_sem % mesh % storage % global2localq
 
       end do
 
@@ -1750,7 +1738,6 @@ module FASMultigridClass
          if ( present(dts) ) then
             if (dts) call ComputePseudoTimeDerivative(this % p_sem % mesh, t, global_dt)
          end if
-         call this % p_sem % mesh % storage % local2globalqdot (this % p_sem % mesh % storage % NDOF)
 
          select type (Acsr => this % A)
             type is (csrMat_t)
@@ -1774,7 +1761,6 @@ module FASMultigridClass
          end select
 
          this % p_sem % mesh % storage % Q = this % p_sem % mesh % storage % Q - this % dQ
-         call this % p_sem % mesh % storage % global2localq
 
       end do
 

--- a/Solver/src/libs/timeintegrator/LinearSolvers/LinearMultigridSolverClass.f90
+++ b/Solver/src/libs/timeintegrator/LinearSolvers/LinearMultigridSolverClass.f90
@@ -686,8 +686,6 @@ contains
          call MG_ComputeJacobians( this,no_levels,ComputeTimeDerivative,Time,dt,nEqn )
       end if
 
-      call this % child % p_sem % mesh % storage % local2globalq (this % child % p_sem % mesh % storage % NDOF)
-
       this % niter = 0
       this % maxiter = maxiter
       this % converged = .false.
@@ -1116,7 +1114,6 @@ contains
          xout = CSR_MatVecMul( this % A, xin ) 
       case (JACOBIANCOMP_MF)
          shift = MatrixShift(this % dt)
-         call this % p_sem % mesh % storage % local2GlobalQ(this % p_sem % NDOF)
          this % Ur   = this % p_sem % mesh % storage % Q
          this % F_Ur = MF_p_F (this % p_sem, this % DimPrb, this % Ur, this % timesolve + this % dt,ComputeTimeDerivative) 
          call MF_JacVecMul(this % p_sem, this % DimPrb, this % Ur, this % F_Ur, xin, xout, this % dt, this % timesolve, shift, ComputeTimeDerivative)

--- a/Solver/src/libs/timeintegrator/LinearSolvers/MatrixFreeGMRESClass.f90
+++ b/Solver/src/libs/timeintegrator/LinearSolvers/MatrixFreeGMRESClass.f90
@@ -623,7 +623,6 @@ contains
          
          if (.not. this % UserDef_Ax) then
             if (.not. associated(this % p_sem) ) error stop 'MatFreeGMRES needs sem or MatrixAction'
-            call this % p_sem % mesh % storage % local2GlobalQ(this % p_sem % NDOF)
             this % Ur   = this % p_sem % mesh % storage % Q
             this % F_Ur = this % p_F (this % Ur, ComputeTimeDerivative)    ! need to compute the time derivative?
          end if
@@ -780,15 +779,12 @@ contains
          
          ! Obtain derivative with new Q
          this % p_sem % mesh % storage % Q = u
-         call this % p_sem % mesh % storage % global2LocalQ
          CALL ComputeTimeDerivative(this % p_sem % mesh, this % p_sem % particles, this % timesolve + this % dtsolve, CTD_IGNORE_MODE)
-         call this % p_sem % mesh % storage % local2GlobalQdot(this % p_sem % NDOF)
          
          F = this % p_sem % mesh % storage % Qdot
 
          ! Restore original Q
          this % p_sem % mesh % storage % Q = u_p   ! TODO: this step can be avoided if Ur is not read in the "child" GMRES (the preconditioner)
-         call this % p_sem % mesh % storage % global2LocalQ
       END FUNCTION p_F
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Solver/src/libs/timeintegrator/LinearSolvers/MatrixFreeSmootherClass.f90
+++ b/Solver/src/libs/timeintegrator/LinearSolvers/MatrixFreeSmootherClass.f90
@@ -459,9 +459,7 @@ CONTAINS
       REAL(KIND = RP)                         :: F(size(u))
       
       this % p_sem % mesh % storage % Q = u
-      call this % p_sem % mesh % storage % global2LocalQ
       CALL ComputeTimeDerivative(this % p_sem % mesh, this % p_sem % particles, timesolve, CTD_IGNORE_MODE)
-      call this % p_sem % mesh % storage % local2GlobalQdot(this % p_sem % NDOF)
       F = this % p_sem % mesh % storage % Qdot
       
    END FUNCTION p_F

--- a/Solver/src/libs/timeintegrator/RosenbrockTimeIntegrator.f90
+++ b/Solver/src/libs/timeintegrator/RosenbrockTimeIntegrator.f90
@@ -189,9 +189,7 @@ contains
          RHS = RHS - Ros_c(j,stage) * this % Y(:,j)
       end do
       
-      call sem % mesh % storage % global2LocalQ
       call ComputeTimeDerivative( sem % mesh, sem % particles, t, CTD_IGNORE_MODE)
-      call sem % mesh % storage % local2GlobalQdot(sem % NDOF)
       
       RHS = RHS/dt - Qdot
       

--- a/Solver/src/libs/timeintegrator/pAdaptationClass.f90
+++ b/Solver/src/libs/timeintegrator/pAdaptationClass.f90
@@ -1072,7 +1072,7 @@ readloop:do
       
       call Stopwatch % Start("pAdapt: Adaptation")
       
-      call sem % mesh % pAdapt (NNew, controlVariables)
+      ! call sem % mesh % pAdapt (NNew, controlVariables)
       
       call Stopwatch % Pause("pAdapt: Adaptation")
       


### PR DESCRIPTION
Right now the solution vector is scattered across all the elements, in small non-contiguous arrays. On top of this, since implicit solvers need a long contiguous vector, we transfer the solution from local to global and vice-versa several times when using these methods.

This PR defines the local storage in terms of pointers to the correct regions of the global array. This means that there is only one solution vector with two different access patterns. The functions `global2Local` and `local2Global` are not necessary anymore, and the memory footprint is somewhat smaller as the arrays are not duplicated. Accelerating implicit methods with GPUs should also be easier now.

Conversely, at least two features still need to be reworked: p-adaptation and the construction of individual elements.