### PR TITLE
Fix utau export from Horses3d

### DIFF
--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -1367,6 +1367,7 @@ Module SurfaceMesh
     Subroutine getU_tauInSurfaces(surfaces, mesh)
         use BoundaryConditions
         use Physics
+        use fluiddata
         implicit none
         type(SurfaceMesh_t)                                     :: surfaces
         type(HexMesh), intent(inout)                            :: mesh
@@ -1374,10 +1375,19 @@ Module SurfaceMesh
         !local variables
         integer                                                 :: surfID, faceID, i, j, meshFaceID
         real(kind=RP)                                           :: u_tau_t1, u_tau_t2
+        real(kind=RP)                                           :: qq, u, v, w
+        real(kind=RP), dimension(NDIM)                          :: freestream_dir
 
 
         if (.not. surfaces % active) return
         if (.not. surfaces % saveUt) return
+
+        u  = cos(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
+        v  = sin(refValues % AoAtheta * PI / 180.0_RP)*cos(refValues % AoAphi * PI / 180.0_RP)
+        w  = sin(refValues % AoAphi * PI / 180.0_RP)
+
+        freestream_dir = [u,v,w]
+
         do surfID = 1, surfaces % numberOfSurfaces
             if (.not. surfaces % surfaceActive(surfID)) cycle
             if ( (surfaces % surfaceTypes(surfID) .ne. SURFACE_TYPE_BC) .or. &
@@ -1396,9 +1406,7 @@ Module SurfaceMesh
                            tangent_2 => mesh % faces(meshFaceID) % geom % t2, &
                            u_tau => mesh % faces(meshFaceID) % storage(1) % u_tau_NS )
                     do j=0,mesh % faces(meshFaceID) % Nf(2)   ; do i = 0, mesh % faces(meshFaceID) % Nf(1)
-                        call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),u_tau_t1)
-                        call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_2(:,i,j),u_tau_t2)
-                        u_tau(i,j) = sqrt(u_tau_t1**2+u_tau_t2**2)
+                        call getFrictionVelocity(Q(:,i,j),U_x(:,i,j),U_y(:,i,j),U_z(:,i,j),normal(:,i,j),tangent_1(:,i,j),tangent_2(:,i,j), freestream_dir, u_tau(i,j))
                     end do             ; end do
                 end associate
 

--- a/Solver/src/libs/physics/navierstokes/Physics_NS.f90
+++ b/Solver/src/libs/physics/navierstokes/Physics_NS.f90
@@ -885,32 +885,50 @@
 
       end subroutine getStressTensor
 
-      Subroutine getFrictionVelocity(Q,Q_x,Q_y,Q_z,normal,tangent,u_tau)
+      Subroutine getFrictionVelocity(Q,Q_x,Q_y,Q_z,normal,tangent_1,tangent_2,freestream_dir, u_tau)
          implicit none
          real(kind=RP), intent(in)      :: Q   (1:NCONS   )
          real(kind=RP), intent(in)      :: Q_x (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_y (1:NGRAD   )
          real(kind=RP), intent(in)      :: Q_z (1:NGRAD   )
          real(kind=RP), intent(in)      :: normal (1:NDIM )
-         real(kind=RP), intent(in)      :: tangent (1:NDIM )
-         real(kind=RP), intent(out)     :: u_tau
+         real(kind=RP), intent(in)      :: tangent_1 (1:NDIM )
+         real(kind=RP), intent(in)      :: tangent_2 (1:NDIM )
+         real(kind=RP), intent(in)      :: freestream_dir (1:NDIM )
+         real(kind=RP), intent(inout)     :: u_tau
 
 !
 !        ---------------
 !        Local variables
 !        ---------------
 !
-         real(kind=RP)                  :: tau (1:NDIM, 1:NDIM   )
+         real(kind=RP)                  :: tau (1:NDIM, 1:NDIM)
          real(kind=RP)                  :: tau_w_vec(1:NDIM)
-         real(kind=RP)                  :: tau_w
+         real(kind=RP)                  :: tau_w_1(1:NDIM)
+         real(kind=RP)                  :: tau_w_2(1:NDIM)
+         real(kind=RP)                  :: tau_w_3(1:NDIM)
+         real(kind=RP)                  :: tangent_3(1:NDIM)
+         real(kind=RP)                  :: tau_w, norm_t3,c1,c2
 
          call getStressTensor(Q, Q_x, Q_y, Q_z, tau)
          tau_w_vec = -1.0_RP * matmul(tau, normal)
-         tau_w = dot_product(tau_w_vec, tangent)
+         tau_w_1 = dot_product(tau_w_vec, tangent_1) * tangent_1
+         tau_w_2 = dot_product(tau_w_vec, tangent_2) * tangent_2
 
-         ! get the value of the friction velocity with the sign of the wall shear stress, so that the shear stress can be fully
-         ! recovered if needed
-         u_tau = sqrt(abs(tau_w) / Q(IRHO)) * sign(1.0_RP, tau_w)
+         tangent_3 = freestream_dir - dot_product(freestream_dir, normal) * normal
+         norm_t3 = sqrt(dot_product(tangent_3, tangent_3))
+         if (norm_t3 > tiny(1.0_RP)) then
+            tangent_3 = tangent_3 / norm_t3
+         else
+            tangent_3 = [0.0_RP, 0.0_RP, 0.0_RP]
+         end if
+         c1 = dot_product(tau_w_1, tangent_3)
+         c2 = dot_product(tau_w_2, tangent_3)
+         
+         tau_w_3 = c1 * tangent_3 + c2 * tangent_3         
+
+         u_tau = sqrt(sqrt(dot_product(tau_w_3, tau_w_3)) / Q(IRHO)) * sign(1.0_RP, dot_product(tau_w_3, tangent_3))
+         
 
       End Subroutine getFrictionVelocity
    END Module Physics_NS


### PR DESCRIPTION
The new export of utau takes a vector of the shear stress that is tangent to the surface and in the direction of the inlet velocity. 