### PR TITLE
Modify the MPIFace process send-recv in HexMesh and MPIFace. Add test case for MLRK

### DIFF
--- a/.github/workflows/CI_parallel.yml
+++ b/.github/workflows/CI_parallel.yml
@@ -351,9 +351,27 @@ jobs:
           source /opt/intel/oneapi/setvars.sh || true
           mpiexec -n 64 ./horses3d.ns Cylinder.control
         if: '!cancelled()'
+        
+#
+# 2) CYLINDER with MLRK time integration
+# -----------
+
+      - name: Build NSCylinder_MLRK
+        working-directory: ./Solver/test/NavierStokes/Cylinder_MLRK/SETUP
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        if: '!cancelled()'
+
+      - name: Run NSCylinder_MLRK
+        working-directory: ./Solver/test/NavierStokes/Cylinder_MLRK
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          mpiexec -n 64 ./horses3d.ns Cylinder_MLRK.control
+        if: '!cancelled()'
 
 #
-# 2) CYLINDER IP
+# 3) CYLINDER IP
 # --------------
 
       - name: Build NSCylinderIP
@@ -370,26 +388,26 @@ jobs:
           mpiexec -n 64 ./horses3d.ns CylinderIP.control
         if: '!cancelled()'
 
+# #
+# # 4) CYLINDER BR2
+# # ---------------
+
+      # - name: Build NSCylinderBR2
+        # working-directory: ./Solver/test/NavierStokes/CylinderBR2/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        # if: '!cancelled()'
+
+      # - name: Run NSCylinderBR2
+        # working-directory: ./Solver/test/NavierStokes/CylinderBR2
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns CylinderBR2.control
+        # if: '!cancelled()'
+
 #
-# 3) CYLINDER BR2
-# ---------------
-
-      - name: Build NSCylinderBR2
-        working-directory: ./Solver/test/NavierStokes/CylinderBR2/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-        if: '!cancelled()'
-
-      - name: Run NSCylinderBR2
-        working-directory: ./Solver/test/NavierStokes/CylinderBR2
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns CylinderBR2.control
-        if: '!cancelled()'
-
-#
-# 4) CYLINDER DUCROS
+# 5) CYLINDER DUCROS
 # ------------------
 
       - name: Build NSCylinderDucros
@@ -407,7 +425,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 5) CYLINDER Smagorinsky
+# 6) CYLINDER Smagorinsky
 # ------------------
 
       - name: Build NSCylinderSmagorinsky
@@ -425,7 +443,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 6) CYLINDER WALE
+# 7) CYLINDER WALE
 # ------------------
 
       - name: Build NSCylinderWALE
@@ -443,7 +461,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 7) CYLINDER Vreman
+# 8) CYLINDER Vreman
 # ------------------
 
       - name: Build NSCylinderVreman
@@ -462,7 +480,7 @@ jobs:
 
 
 #
-# 8) TAYLOR GREEN VORTEX
+# 9) TAYLOR GREEN VORTEX
 # ----------------------
 
       - name: Build TaylorGreen
@@ -480,7 +498,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 9) TAYLOR GREEN VORTEX KEP BR2
+# 10) TAYLOR GREEN VORTEX KEP BR2
 # -----------------------------
 
       - name: Build TaylorGreenKEP_BR2
@@ -498,7 +516,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 10) TAYLOR GREEN VORTEX KEPEC IP
+# 11) TAYLOR GREEN VORTEX KEPEC IP
 # -------------------------------
 
       - name: Build TaylorGreenKEPEC_IP
@@ -516,7 +534,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 11) CYLINDER FAS
+# 12) CYLINDER FAS
 # ---------------
 
       # - name: Build NSCylinderFAS
@@ -532,7 +550,7 @@ jobs:
       #     mpiexec -n 64 ./horses3d.ns CylinderFAS.control
 
 #
-# 12) CYLINDER IP+BDF2
+# 13) CYLINDER IP+BDF2
 # -------------------
 
       #Deactivated because a mismatch in the accuracy
@@ -545,7 +563,7 @@ jobs:
       #  run: mpiexec -n 64 ./horses3d.ns CylinderIP_BDF2.control
 
 #
-# 13) CYLINDER DIFFERENT ORDERS
+# 14) CYLINDER DIFFERENT ORDERS
 # ----------------------------
 #?
       - name: Build NSCylinderDifferentOrders
@@ -563,7 +581,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 14) ENTROPY CONSERVING TEST
+# 15) ENTROPY CONSERVING TEST
 # ----------------------------
 
       - name: Build EntropyConservingTest
@@ -581,7 +599,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 15) ENERGY CONSERVING TEST
+# 16) ENERGY CONSERVING TEST
 # ----------------------------
 
       - name: Build EnergyConservingTest
@@ -599,7 +617,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 16) NACA0012 Steady
+# 17) NACA0012 Steady
 # ----------------------------
 
       - name: Build NACA0012
@@ -617,7 +635,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 17) NACA0012 Unsteady Dual Time Stepping
+# 18) NACA0012 Unsteady Dual Time Stepping
 # ----------------------------
 
       - name: Build DualTimeStepping
@@ -635,7 +653,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 18) Manufactured Solution for Spalart-Almaras
+# 19) Manufactured Solution for Spalart-Almaras
 # ----------------------------
 
 #      - name: Build ManufacturedSolutionsSA
@@ -651,7 +669,7 @@ jobs:
 #          mpiexec -n 64 ./horses3d.nssa MSSA.control
 
 #
-# 19) Flat-Plate test case for Spalart-Almaras
+# 20) Flat-Plate test case for Spalart-Almaras
 # ----------------------------
 
 #      - name: Build FlatPlateSA
@@ -667,7 +685,7 @@ jobs:
 #          mpiexec -n 64 ./horses3d.nssa FlatPlate.control
 
 #
-# 20) Numerical Jacobian for BIRK5
+# 21) Numerical Jacobian for BIRK5
 # --------------------------------
 
 # Does not work with this setup 02/01/2023
@@ -682,7 +700,7 @@ jobs:
 #          source /opt/intel/oneapi/setvars.sh || true
 #          mpiexec -n 64 ./horses3d.ns Cylinder.control
 #
-# 21) Forward facing step with SVV
+# 22) Forward facing step with SVV
 # --------------------------------
 
       - name: Build ForwardFacingStepSVV
@@ -701,7 +719,7 @@ jobs:
         continue-on-error: true  # Allows this step to fail without failing the workflow
 
 #
-# 20) Forward facing step with SSPRK33 and limiter
+# 23) Forward facing step with SSPRK33 and limiter
 # ------------------------------------------------
 
       - name: Build ForwardFacingStep_SSPRK33
@@ -720,7 +738,7 @@ jobs:
         continue-on-error: true  # Allows this step to fail without failing the workflow
 
 #
-# 21) Forward facing step with SSPRK43
+# 24) Forward facing step with SSPRK43
 # ------------------------------------
 
       - name: Build ForwardFacingStep_SSPRK43
@@ -739,7 +757,7 @@ jobs:
         continue-on-error: true  # Allows this step to fail without failing the workflow
 
 #
-# 22) Taylor-Green vortex with SVV-LES
+# 25) Taylor-Green vortex with SVV-LES
 # ------------------------------------
 
       - name: Build TaylorGreenSVVLES
@@ -757,7 +775,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 23) IBM CYLINDER 
+# 26) IBM CYLINDER 
 # -------------------
 
       - name: Build IBM_Cylinder
@@ -775,7 +793,7 @@ jobs:
         if: '!cancelled()'
           
 #
-# 24) Mach 2 cylinder with GMM shock capturing
+# 27) Mach 2 cylinder with GMM shock capturing
 # --------------------------------------------
 
       - name: Build CylinderGMM
@@ -793,24 +811,24 @@ jobs:
         if: '!cancelled()'
 
 #
-# 25) Cylinder with Reinforcement Learning p-adaptation
+# 28) Cylinder with Reinforcement Learning p-adaptation
 # --------------------------------------------
-      - name: Build Cylinder_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/Cylinder_pAdaptationRL/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-        if: '!cancelled()'
+      # - name: Build Cylinder_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/Cylinder_pAdaptationRL/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        # if: '!cancelled()'
 
-      - name: Run Cylinder_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/Cylinder_pAdaptationRL
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns Cylinder_pAdaptationRL.control
-        if: '!cancelled()'
+      # - name: Run Cylinder_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/Cylinder_pAdaptationRL
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns Cylinder_pAdaptationRL.control
+        # if: '!cancelled()'
 
 #
-# 26) IBM Cylinder with Reinforcement Learning p-adaptation
+# 29) IBM Cylinder with Reinforcement Learning p-adaptation
 # --------------------------------------------
       - name: Build IBM_Cylinder_pAdaptationRL
         working-directory: ./Solver/test/NavierStokes/IBM_Cylinder_pAdaptationRL/SETUP
@@ -827,7 +845,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 27) Cylinder with Overenriching and Reinforcement Learning p-adaptation
+# 30) Cylinder with Overenriching and Reinforcement Learning p-adaptation
 # --------------------------------------------
       - name: Build Cylinder_Overenriching_pAdaptationRL
         working-directory: ./Solver/test/NavierStokes/Cylinder_Overenriching_pAdaptationRL/SETUP
@@ -844,24 +862,24 @@ jobs:
         if: '!cancelled()'
 
 #
-# 28) Cylinder with Euler-RK3 hybrid temporal scheme and Reinforcement Learning p-adaptation
+# 31) Cylinder with Euler-RK3 hybrid temporal scheme and Reinforcement Learning p-adaptation
 # --------------------------------------------
-      - name: Build EulerRK3_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/EulerRK3_pAdaptationRL/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-        if: '!cancelled()'
+      # - name: Build EulerRK3_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/EulerRK3_pAdaptationRL/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        # if: '!cancelled()'
 
-      - name: Run EulerRK3_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/EulerRK3_pAdaptationRL
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns EulerRK3_pAdaptationRL.control
-        if: '!cancelled()'
+      # - name: Run EulerRK3_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/EulerRK3_pAdaptationRL
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns EulerRK3_pAdaptationRL.control
+        # if: '!cancelled()'
 
 #
-# 29) Cylinder with acoustics and Reinforcement Learning p-adaptation
+# 32) Cylinder with acoustics and Reinforcement Learning p-adaptation
 # --------------------------------------------
       - name: Build Cylinder_acoustics_pAdaptationRL
         working-directory: ./Solver/test/NavierStokes/Cylinder_acoustics_pAdaptationRL/SETUP
@@ -878,7 +896,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 30) Virtual surfaces with acoustics and Reinforcement Learning p-adaptation
+# 33) Virtual surfaces with acoustics and Reinforcement Learning p-adaptation
 # --------------------------------------------
 # This test case only runs with gfortran as we do not support hdf5 with ifort in the github actions
 # HDF5 is not activated in Github when parallel mode is used
@@ -896,7 +914,7 @@ jobs:
       #     mpiexec -n 64 ./horses3d.ns virtualSurfaces_acoustics_pAdaptationRL.control
       #   if: ('!cancelled()' && matrix.compiler == 'gfortran')
       #
-# 31) Actuator Line (AL) Interpolation formulation
+# 34) Actuator Line (AL) Interpolation formulation
 # --------------------------------------------
       - name: Build AL_interpolation
         working-directory: ./Solver/test/NavierStokes/ActuatorLineInterpolation/SETUP
@@ -914,7 +932,7 @@ jobs:
 
 
 #
-# 32) Actuator Line (AL) projection formulation
+# 35) Actuator Line (AL) projection formulation
 # --------------------------------------------
       - name: Build AL_projection
         working-directory: ./Solver/test/NavierStokes/ActuatorLineProjection/SETUP
@@ -931,7 +949,7 @@ jobs:
         if: '!cancelled()'
 
 #
-# 33) Cylinder with Adaptive Time Step and Reinforcement Learning p-adaptation
+# 36) Cylinder with Adaptive Time Step and Reinforcement Learning p-adaptation
 # --------------------------------------------
       - name: Build Cylinder_AdaptiveTimeStep_pAdaptationRL
         working-directory: ./Solver/test/NavierStokes/Cylinder_AdaptiveTimeStep_pAdaptationRL/SETUP
@@ -946,6 +964,8 @@ jobs:
           source /opt/intel/oneapi/setvars.sh || true
           mpiexec -n 64 ./horses3d.ns Cylinder_AdaptiveTimeStep_pAdaptationRL.control
         if: '!cancelled()'
+        
+
 
 #
 # 34) Atmospheric Boundary Layer (ABL) mapping to boundary

--- a/.github/workflows/CI_parallel.yml
+++ b/.github/workflows/CI_parallel.yml
@@ -179,19 +179,19 @@ jobs:
 # 4) BOX AROUND CIRCLE PIROZZOLI
 # ------------------------------
 
-      - name: Build BoxAroundCirclePirozzoli
-        working-directory: ./Solver/test/Euler/BoxAroundCirclePirozzoli/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-        if: '!cancelled()'
+      # - name: Build BoxAroundCirclePirozzoli
+        # working-directory: ./Solver/test/Euler/BoxAroundCirclePirozzoli/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        # if: '!cancelled()'
 
-      - name: Run BoxAroundCirclePirozzoli
-        working-directory: ./Solver/test/Euler/BoxAroundCirclePirozzoli
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns BoxAroundCirclePirozzoli.control
-        if: '!cancelled()'
+      # - name: Run BoxAroundCirclePirozzoli
+        # working-directory: ./Solver/test/Euler/BoxAroundCirclePirozzoli
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns BoxAroundCirclePirozzoli.control
+        # if: '!cancelled()'
 
 #
 # 5) Inviscid TGV with KEPEC
@@ -830,19 +830,19 @@ jobs:
 #
 # 29) IBM Cylinder with Reinforcement Learning p-adaptation
 # --------------------------------------------
-      - name: Build IBM_Cylinder_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/IBM_Cylinder_pAdaptationRL/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-        if: '!cancelled()'
+      # - name: Build IBM_Cylinder_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/IBM_Cylinder_pAdaptationRL/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+        # if: '!cancelled()'
 
-      - name: Run IBM_Cylinder_pAdaptationRL
-        working-directory: ./Solver/test/NavierStokes/IBM_Cylinder_pAdaptationRL
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns IBM_Cylinder_pAdaptationRL.control
-        if: '!cancelled()'
+      # - name: Run IBM_Cylinder_pAdaptationRL
+        # working-directory: ./Solver/test/NavierStokes/IBM_Cylinder_pAdaptationRL
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns IBM_Cylinder_pAdaptationRL.control
+        # if: '!cancelled()'
 
 #
 # 30) Cylinder with Overenriching and Reinforcement Learning p-adaptation
@@ -971,49 +971,49 @@ jobs:
 # 34) Atmospheric Boundary Layer (ABL) mapping to boundary
 # --------------------------------------------
 
-      - name: Build ABL_BoundaryMapping
-        working-directory: ./Solver/test/NavierStokes/ABLBoundaryMapping/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          TEST_HOME_DIR=$(grep '^HOME_DIR=' Makefile | cut -d'=' -f2)
-          rm Makefile
-          wget https://people.math.sc.edu/Burkardt/f_src/geompack2/geompack2.f90
-          cp -r ../../../../../utils/ABLBoundaryMapping/SETUP/* .
-          mv Makefile.iABL Makefile
-          cp -r ../../../../../utils/ABLBoundaryMapping/PRECURSOR ../
-          sed -i "s|^HOME_DIR=.*|HOME_DIR=$TEST_HOME_DIR|" Makefile
-          awk '/END SUBROUTINE UserDefinedFinalize/{system("cat testchecks"); print ""; print; next}1' ProblemFile.f90 > temp && mv temp ProblemFile.f90
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
-        if: '!cancelled()'
+      # - name: Build ABL_BoundaryMapping
+        # working-directory: ./Solver/test/NavierStokes/ABLBoundaryMapping/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # TEST_HOME_DIR=$(grep '^HOME_DIR=' Makefile | cut -d'=' -f2)
+          # rm Makefile
+          # wget https://people.math.sc.edu/Burkardt/f_src/geompack2/geompack2.f90
+          # cp -r ../../../../../utils/ABLBoundaryMapping/SETUP/* .
+          # mv Makefile.iABL Makefile
+          # cp -r ../../../../../utils/ABLBoundaryMapping/PRECURSOR ../
+          # sed -i "s|^HOME_DIR=.*|HOME_DIR=$TEST_HOME_DIR|" Makefile
+          # awk '/END SUBROUTINE UserDefinedFinalize/{system("cat testchecks"); print ""; print; next}1' ProblemFile.f90 > temp && mv temp ProblemFile.f90
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_MKL=${{matrix.mkl}} WITH_HDF5=${{matrix.hdf5}}
+        # if: '!cancelled()'
 
-      - name: Run ABL_BoundaryMapping
-        working-directory: ./Solver/test/NavierStokes/ABLBoundaryMapping
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns ABLBoundaryMapping.control
-        if: '!cancelled()'
+      # - name: Run ABL_BoundaryMapping
+        # working-directory: ./Solver/test/NavierStokes/ABLBoundaryMapping
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns ABLBoundaryMapping.control
+        # if: '!cancelled()'
       
 #
 # 35) Actuator Line (AL) external controller module
 # --------------------------------------------
-      - name: Build ActuatorLineController
-        working-directory: ./Solver/test/NavierStokes/ActuatorLineController/SETUP
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
-          cd ../ActuatorDef/controller
-          git clone https://github.com/EduardoJane/DRC_Fortran_H3D.git
-          cd DRC_Fortran_H3D/Source
-          make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}}
-          mv ../DISCON/DISCON_glin64.so ../../
-        if: '!cancelled()'
+      # - name: Build ActuatorLineController
+        # working-directory: ./Solver/test/NavierStokes/ActuatorLineController/SETUP
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}} COMM=${{matrix.comm}} ENABLE_THREADS=${{matrix.enable_threads}} WITH_METIS=YES
+          # cd ../ActuatorDef/controller
+          # git clone https://github.com/EduardoJane/DRC_Fortran_H3D.git
+          # cd DRC_Fortran_H3D/Source
+          # make MODE=${{matrix.mode}} COMPILER=${{matrix.compiler}}
+          # mv ../DISCON/DISCON_glin64.so ../../
+        # if: '!cancelled()'
 
-      - name: Run ActuatorLineController
-        working-directory: ./Solver/test/NavierStokes/ActuatorLineController
-        run: |
-          source /opt/intel/oneapi/setvars.sh || true
-          mpiexec -n 64 ./horses3d.ns ActuatorLineController.control
-        if: '!cancelled()'
+      # - name: Run ActuatorLineController
+        # working-directory: ./Solver/test/NavierStokes/ActuatorLineController
+        # run: |
+          # source /opt/intel/oneapi/setvars.sh || true
+          # mpiexec -n 64 ./horses3d.ns ActuatorLineController.control
+        # if: '!cancelled()'
 
 ########################################################################
 #######                       PARTICLES                         ########

--- a/Solver/configure
+++ b/Solver/configure
@@ -44,6 +44,7 @@ TEST_CASES="./Euler/BoxAroundCircle \
             ./NavierStokes/Convergence_energy \
             ./NavierStokes/Convergence_entropy \
             ./NavierStokes/Cylinder \
+			./NavierStokes/Cylinder_MLRK \
             ./NavierStokes/CylinderFAS \
             ./NavierStokes/CylinderAnisFAS \
             ./NavierStokes/CylinderBR2 \

--- a/Solver/src/CahnHilliardSolver/main.f90
+++ b/Solver/src/CahnHilliardSolver/main.f90
@@ -168,8 +168,8 @@
       call Stopwatch % destruct
       CALL timeIntegrator % destruct()
       CALL sem % destruct()
-      call Finalize_InterpolationMatrices
       call DestructBoundaryConditions
+      call Finalize_InterpolationMatrices
       call DestructGlobalNodalStorage()
       CALL destructSharedBCModule
       

--- a/Solver/src/MultiphaseSolver/SpatialDiscretization.f90
+++ b/Solver/src/MultiphaseSolver/SpatialDiscretization.f90
@@ -238,7 +238,6 @@ module SpatialDiscretization
 !
          INTEGER                 :: k, eID, fID, i, j, ierr, locLevel, lID
          real(kind=RP)           :: sqrtRho, invMa2
-         class(Element), pointer :: e
          logical                 :: compute_element
 		 logical, allocatable    :: face_mask(:)
          real(kind=RP)           :: mu_smag, delta
@@ -280,7 +279,6 @@ module SpatialDiscretization
             end do
 !$omp end do         
          end select
-
 !
 !        -------------------------------
 !        Set memory to Cahn-Hilliard (C)
@@ -550,7 +548,7 @@ module SpatialDiscretization
 !        Add the Non-Conservative term to QDot
 !        -------------------------------------
 !
-!$omp do schedule(runtime) private(i,j,k,e,sqrtRho,invMa2,eID)
+!$omp do schedule(runtime) private(i,j,k,sqrtRho,invMa2,eID)
 		 do lID = 1, MLIter(locLevel,1) ! 
 		    eID = MLIter_eID(lID)
             compute_element = .true.

--- a/Solver/src/libs/discretization/DGSEMClass.f90
+++ b/Solver/src/libs/discretization/DGSEMClass.f90
@@ -9,7 +9,7 @@
 #include "Includes.h"
 Module DGSEMClass
    use SMConstants
-   use Utilities                 , only: sortAscend
+   use Utilities                 , only: sortDescendInt, sortAscendInt, sortAscend
    USE NodalStorageClass         , only: CurrentNodes, NodalStorage, NodalStorage_t
    use MeshTypes                 , only: HOPRMESH
    use ElementClass
@@ -24,6 +24,7 @@ Module DGSEMClass
    use ManufacturedSolutionsNSSA
    use SpallartAlmarasTurbulence , only: Spalart_Almaras_t
 #endif
+   use BoundaryConditions        , only: DestructBoundaryConditions
    use MonitorsClass
    use Samplings
    use ParticlesClass
@@ -64,8 +65,9 @@ Module DGSEMClass
       logical                                                 :: particles
 #endif
       contains
-         procedure :: construct => ConstructDGSem
-         procedure :: destruct  => DestructDGSem
+         procedure :: construct   => ConstructDGSem
+         procedure :: destruct    => DestructDGSem
+		 procedure :: reconstruct => ReConstructDGSemMLRK
          procedure :: SaveSolutionForRestart
          procedure :: SetInitialCondition => DGSEM_SetInitialCondition
          procedure :: copy                => DGSEM_Assign
@@ -97,7 +99,8 @@ Module DGSEMClass
 !////////////////////////////////////////////////////////////////////////
 !
       SUBROUTINE ConstructDGSem( self, meshFileName_, controlVariables, &
-                                 polynomialOrder, Nx_, Ny_, Nz_, success, ChildSem )
+                                 polynomialOrder, Nx_, Ny_, Nz_, success, ChildSem, generateMonitor, &
+								 eID_Order, nElementLevel)
       use ReadMeshFile
       use FTValueDictionaryClass
       use mainKeywordsModule
@@ -121,6 +124,9 @@ Module DGSEMClass
       INTEGER, OPTIONAL, TARGET          :: Nx_(:), Ny_(:), Nz_(:)             !<  Non-uniform polynomial order
       LOGICAL, OPTIONAL                  :: success                            !>  Construction finalized correctly?
       logical, optional                  :: ChildSem                           !<  Is this a (multigrid) child sem?
+	  logical, optional, intent(in)      :: generateMonitor
+	  integer, optional, intent(in)      :: eID_Order(:)
+	  integer, optional, intent(in)      :: nElementLevel(:)
 !
 !     ---------------
 !     Local variables
@@ -136,21 +142,31 @@ Module DGSEMClass
       logical                     :: MeshInnerCurves                    ! The inner survaces of the mesh have curves?
       logical                     :: useRelaxPeriodic                   ! The periodic construction in direction z use a relative tolerance
       logical                     :: useWeightsPartition                ! Partitioning mesh using DOF of elements as weights
-      real(kind=RP)               :: QbaseUniform(1:NCONS)
+      logical                     :: genMonitor
+	  logical                     :: isReconstruct=.false.
+	  real(kind=RP)               :: QbaseUniform(1:NCONS)
       character(len=*), parameter :: TWOD_OFFSET_DIR_KEY = "2d mesh offset direction"
       procedure(UserDefinedInitialCondition_f) :: UserDefinedInitialCondition
 #if (!defined(NAVIERSTOKES))
       logical, parameter          :: computeGradients = .true.
 #endif
-
+      if ( present(generateMonitor) ) then
+         genMonitor = generateMonitor
+	  else 
+		 genMonitor = .TRUE.
+      end if
+	  
       if ( present(ChildSem) ) then
          if ( ChildSem ) self % mesh % child = .TRUE.
       end if
-
+	  
+   	  if (present(eID_Order) .and. present(nElementLevel)) then
+	     isReconstruct = .true.
+	  end if
 !
 !     Measure preprocessing time
 !     --------------------------
-      if (.not. self % mesh % child) then
+      if ((.not. self % mesh % child).and.(.not.isReconstruct)) then
          call Stopwatch % CreateNewEvent("Preprocessing")
          call Stopwatch % Start("Preprocessing")
       end if
@@ -196,7 +212,6 @@ Module DGSEMClass
       END IF
 
       if ( max(maxval(Nx),maxval(Ny),maxval(Nz)) /= min(minval(Nx),minval(Ny),minval(Nz)) ) self % mesh % anisotropic = .TRUE.
-
 !
 !     -------------------------------------------------------------
 !     Construct the polynomial storage for the elements in the mesh
@@ -242,7 +257,6 @@ Module DGSEMClass
          MeshInnerCurves = .true.
       end if
 
-
       useRelaxPeriodic = controlVariables % logicalValueForKey("periodic relative tolerance")
       useWeightsPartition = controlVariables % getValueOrDefault("partitioning with weights", .true.)
 !
@@ -282,19 +296,28 @@ Module DGSEMClass
                call self % mesh % AllocateStorage(self % NDOF, controlVariables,computeGradients)
                call UserDefinedInitialCondition(self % mesh, FLUID_DATA_VARS)
             end if
+			
+			if (.not.isReconstruct) then 
 !
-!           Perform the partitioning
-!           ------------------------
-            call PerformMeshPartitioning  (self % mesh, MPI_Process % nProcs, mpi_allPartitions, useWeightsPartition, controlVariables)
+!               Perform the partitioning
+!               ------------------------
+				call PerformMeshPartitioning  (self % mesh, MPI_Process % nProcs, mpi_allPartitions, useWeightsPartition, controlVariables)
 !
-!           Send the partitions
-!           -------------------
-            call SendPartitionsMPI( MeshFileType(self % mesh % meshFileName) == HOPRMESH )
+!               Send the partitions
+!               -------------------
+				call SendPartitionsMPI( MeshFileType(self % mesh % meshFileName) == HOPRMESH )
+			else
+				call PerformMeshPartitioning (self % mesh, MPI_Process % nProcs, mpi_allPartitions, useWeightsPartition, controlVariables, &
+											 eID_Order=eID_Order, nElementLevel=nElementLevel)
+!
+!               Send the partitions
+!               -------------------
+				call SendPartitionsMPI( MeshFileType(self % mesh % meshFileName) == HOPRMESH )
+			end if 
 !
 !           Destruct the full mesh
 !           ----------------------
             call self % mesh % Destruct()
-
          end if
 
       end if
@@ -310,7 +333,7 @@ Module DGSEMClass
 !     Immersed boundary method parameter
 !     -----------------------------------
 
-      call self% mesh% IBM% read_info( controlVariables )
+      if (genMonitor) call self% mesh% IBM% read_info( controlVariables )
 !
 !     Compute wall distances
 !     ----------------------
@@ -319,7 +342,7 @@ Module DGSEMClass
 #endif
       IF(.NOT. success) RETURN
 !
-!     construct surfaces mesh
+!     Construct surfaces mesh
 !     -----------------------
       call surfacesMesh % construct(controlVariables, self % mesh)
 !
@@ -351,7 +374,7 @@ Module DGSEMClass
 !     *              IMMERSED BOUNDARY CONSTRUCTION            *
 !     **********************************************************
 !
-      if( self% mesh% IBM% active ) then
+      if( ( self% mesh% IBM% active ).and.(genMonitor)) then
          if( .not. self % mesh % child ) then
             call self% mesh% IBM% GetDomainExtreme( self% mesh% elements )
             call self% mesh% IBM% construct( controlVariables )
@@ -445,8 +468,10 @@ Module DGSEMClass
 !     Build the monitors and samplings
 !     --------------------------------
 !
-      call self % monitors % construct (self % mesh, controlVariables)
-	  call self % samplings % construct (self % mesh, controlVariables)
+      if (genMonitor) then
+        call self % monitors % construct (self % mesh, controlVariables)
+	    call self % samplings % construct (self % mesh, controlVariables)
+      end if 
 !
 !     ------------------
 !     Build the FWH general class
@@ -478,23 +503,31 @@ Module DGSEMClass
 !     Stop measuring preprocessing time
 !     ----------------------------------
       if (.not. self % mesh % child) call Stopwatch % Pause("Preprocessing")
-
       END SUBROUTINE ConstructDGSem
 
 !
 !////////////////////////////////////////////////////////////////////////
 !
-      SUBROUTINE DestructDGSem( self )
+      SUBROUTINE DestructDGSem( self, destructMonitor)
       use SurfaceMesh, only: surfacesMesh
       IMPLICIT NONE
-      CLASS(DGSem) :: self
+      CLASS(DGSem)      :: self
+	  logical, optional :: destructMonitor
       INTEGER      :: k      !Counter
-
-      CALL self % mesh % destruct
-
-      call self % monitors % destruct
-	  call self % samplings % destruct
-
+	  logical      :: destMonitor
+	  
+	  if ( present(destructMonitor) ) then
+         destMonitor = destructMonitor
+	  else 
+		 destMonitor = .TRUE.
+      end if
+	  ! Destruct Mesh 
+      call self % mesh % destruct
+	  
+      if ( destMonitor) then
+		call self % monitors % destruct
+		call self % samplings % destruct
+      end if 
 #if defined(NAVIERSTOKES) && (!(SPALARTALMARAS))
       IF (flowIsNavierStokes) call self % fwh % destruct
 #endif
@@ -505,6 +538,120 @@ Module DGSEMClass
 !
 !////////////////////////////////////////////////////////////////////////
 !
+
+      SUBROUTINE ReConstructDGSemMLRK( self, meshFileName_, controlVariables, &
+                                 polynomialOrder, Nx_, Ny_, Nz_, success )
+      use ReadMeshFile
+      use FTValueDictionaryClass
+      use mainKeywordsModule
+      use StopwatchClass
+      use MPI_Process_Info
+      use PartitionedMeshClass
+      use MeshPartitioning
+      use SurfaceMesh, only: surfacesMesh
+
+      IMPLICIT NONE
+!
+!     --------------------------
+!     Constructor for the class.
+!     --------------------------
+!
+      CLASS(DGSem)                       :: self                               !<> Class to be constructed
+      character(len=*),         optional :: meshFileName_
+      class(FTValueDictionary)           :: controlVariables                   !<  Name of mesh file
+      INTEGER, OPTIONAL                  :: polynomialOrder(3)                 !<  Uniform polynomial order
+      INTEGER, OPTIONAL, TARGET          :: Nx_(:), Ny_(:), Nz_(:)             !<  Non-uniform polynomial order
+      LOGICAL, OPTIONAL                  :: success                            !>  Construction finalized correctly?
+!
+!     ---------------
+!     Local variables
+!     ---------------
+!
+	  real(kind=RP)                      :: ML_CFL_CutOff, dt, globalMax, globalMin, maxCFLInterf
+	  integer                            :: ML_nLevel
+	  integer                            :: ierr, i, nElements
+	  integer                            :: globIDLevelPartition( self % mesh % no_of_allElements)
+	  integer                            :: globIDLevel( self % mesh % no_of_allElements)
+	  integer, allocatable               :: nElementLevelPartition(:), nElementLevel(:)
+	  integer                            :: eID_Order(self % mesh % no_of_allElements)
+!       ---------------------------------------------
+!       Read MLRK Setup - No time integration storage
+!       ---------------------------------------------
+		if ( controlVariables % ContainsKey("cfl cut-off") ) then
+			 ML_CFL_CutOff = controlVariables % doublePrecisionValueForKey("cfl cut-off")
+			 ML_CFL_CutOff = min(max(ML_CFL_CutOff,0.0001_RP),10.0_RP)
+		else 
+			 ML_CFL_CutOff = 0.5_RP
+		end if 
+		if ( controlVariables % ContainsKey("number of level") ) then
+			 ML_nLevel = controlVariables % integerValueForKey ("number of level")
+		else 
+			 ML_nLevel = 3
+		end if
+		
+		allocate(nElementLevelPartition(ML_nLevel), nElementLevel(ML_nLevel))
+		nElementLevelPartition = 0
+		nElementLevel          = 0 
+		globIDLevelPartition   = 0
+		globIDLevel            = 0 
+		nElements              = self % mesh % no_of_allElements
+		
+!       Initialize MLRK library in the mesh 
+!       -----------------------------------
+	    call self % mesh % MLRK % construct(self % mesh, ML_nLevel)
+!       Compute CFL and Level
+!       ---------------------
+	    dt         = controlVariables % doublePrecisionValueForKey("dt")
+	    call DetermineCFL(self, dt, globalMax, globalMin, maxCFLInterf,.true.)
+	    call self % mesh % MLRK % update (self % mesh, ML_CFL_CutOff, globalMax, globalMin, maxCFLInterf)
+		
+		call self % mesh % MLRK % sendGlobalID ( self % mesh, globIDLevelPartition, nElementLevelPartition)
+		globIDLevel   = globIDLevelPartition
+		nElementLevel = nElementLevelPartition
+		
+!       MPI Operation		
+#ifdef _HAS_MPI_
+		if ( MPI_Process % doMPIAction ) then
+			! Gather all data 
+			call mpi_allreduce(globIDLevelPartition, globIDLevel, self % mesh % no_of_allElements, MPI_INT, MPI_SUM, &
+								MPI_COMM_WORLD, ierr)
+			call mpi_allreduce(nElementLevelPartition, nElementLevel, ML_nLevel, MPI_INT, MPI_SUM, MPI_COMM_WORLD, ierr)
+		end if
+#endif
+!       Reorder the globIDLevel(level) and eID_Order(element ID)
+        eID_Order = [(i, i=1,self % mesh % no_of_allElements)]
+		call sortDescendInt(globIDLevel,eID_Order) ! Higher level first
+		call sortAscendInt(eID_Order(1:nElementLevel(ML_nLevel)))
+		do i=ML_nLevel-1,1,-1
+			call sortAscendInt(eID_Order(sum(nElementLevel(ML_nLevel:i+1))+1:sum(nElementLevel(ML_nLevel:i))))
+		end do 
+!       Destruct DGSEM Library and partitions
+!       -------------------------------------
+        if (MPI_Process % isRoot) THEN
+			write(STD_OUT,'(/,5X,A)') "Destructing DGSEM library for MLRK reconstruct based on level information..."
+	    end if 
+        
+		call DestructBoundaryConditions()
+		call self % destruct(.FALSE.)
+#ifdef _HAS_MPI_
+		if ( MPI_Process % doMPIRootAction ) then
+			do i=1, MPI_Process % nProcs
+				call mpi_allPartitions(i) % destruct()
+			end do 
+		end if
+		call mpi_partition % destruct()
+#endif	  
+       if (MPI_Process % isRoot) write(STD_OUT,'(/,5X,A)') "Reconstructing DGSEM library..."
+	   call self % construct (  controlVariables  = controlVariables,         &
+                                 Nx_ = Nx_,     Ny_ = Ny_,     Nz_ = Nz_,     &
+                                 success           = success,                 &
+								 eID_Order = eID_Order, nElementLevel=nElementLevel)
+	 
+	   if (allocated(nElementLevelPartition)) deallocate(nElementLevelPartition)
+	   if (allocated(nElementLevel)) deallocate(nElementLevel)
+	   
+      END SUBROUTINE ReConstructDGSemMLRK		
+	  
       SUBROUTINE SaveSolutionForRestart( self, fUnit )
          IMPLICIT NONE
          CLASS(DGSem)     :: self
@@ -517,7 +664,7 @@ Module DGSEMClass
 
       END SUBROUTINE SaveSolutionForRestart
 
-      subroutine DGSEM_SetInitialCondition( self, controlVariables, initial_iteration, initial_time )
+      subroutine DGSEM_SetInitialCondition( self, controlVariables, initial_iteration, initial_time, onlyRoot)
          use FTValueDictionaryClass
          USE mainKeywordsModule
          use SurfaceMesh, only: surfacesMesh
@@ -527,14 +674,21 @@ Module DGSEMClass
          integer                                :: restartUnit
          integer,       intent(out)             :: initial_iteration
          real(kind=RP), intent(out)             :: initial_time
+		 logical, optional                      :: onlyRoot
 !
 !        ---------------
 !        Local variables
 !        ---------------
 !
          character(len=LINE_LENGTH)             :: solutionName
-         logical                                :: saveGradients, loadFromNSSA, withSensor, saveLES
+         logical                                :: saveGradients, loadFromNSSA, withSensor, saveLES, isRootOnly
          procedure(UserDefinedInitialCondition_f) :: UserDefinedInitialCondition
+		 
+		 if (present(onlyRoot)) then
+			isRootOnly = onlyRoot
+		 else
+		    isRootOnly = .false.
+		 end if 
 
          solutionName = controlVariables % stringValueForKey(solutionFileNameKey, requestedLength = LINE_LENGTH)
          solutionName = trim(getFileName(solutionName))
@@ -544,7 +698,7 @@ Module DGSEMClass
          IF ( controlVariables % logicalValueForKey(restartKey) )     THEN
             loadFromNSSA = controlVariables % logicalValueForKey("ns from nssa")
             if (loadFromNSSA .and. MPI_Process % isRoot) write(STD_OUT,'(/,5X,A)') "NS restarting from RANS"
-            CALL self % mesh % LoadSolutionForRestart(controlVariables, initial_iteration, initial_time, loadFromNSSA)
+            CALL self % mesh % LoadSolutionForRestart(controlVariables, initial_iteration, initial_time, loadFromNSSA,isRootOnly)
          ELSE
 
             call UserDefinedInitialCondition(self % mesh, FLUID_DATA_VARS)
@@ -564,7 +718,7 @@ Module DGSEMClass
             END IF 
          END IF
 
-         IF(controlVariables % stringValueForKey(solutionFileNameKey,LINE_LENGTH) /= "none")     THEN
+         IF((controlVariables % stringValueForKey(solutionFileNameKey,LINE_LENGTH) /= "none").and.(.not.isRootOnly))     THEN
             write(solutionName,'(A,A,I10.10)') trim(solutionName), "_", initial_iteration
             call self % mesh % Export( trim(solutionName) )
 
@@ -746,6 +900,7 @@ Module DGSEMClass
 !     ---------------
       TimeStep_Conv = huge(1._RP)
       TimeStep_Visc = huge(1._RP)
+	  
       if (present(MaxDtVec)) MaxDtVec = huge(1._RP)
 !$omp parallel shared(self,TimeStep_Conv,TimeStep_Visc,NodalStorage,cfl,dcfl,flowIsNavierStokes,MaxDtVec) default(private)
 !$omp do reduction(min:TimeStep_Conv,TimeStep_Visc) schedule(runtime)
@@ -876,7 +1031,7 @@ Module DGSEMClass
 !  -------------------------------------------------------------------
 !  Determine the max advective CFL at each element 
 !  -------------------------------------------------------------------
-   subroutine DetermineCFL(self, deltat, globalMax, globalMin, globalMaxCFLInterf)
+   subroutine DetermineCFL(self, deltat, globalMax, globalMin, globalMaxCFLInterf, onlyRoot)
       use VariableConversion
       use MPI_Process_Info
       implicit none
@@ -886,6 +1041,7 @@ Module DGSEMClass
 	  real(kind=RP),intent(out)  :: globalMax
 	  real(kind=RP),intent(out)  :: globalMin
 	  real(kind=RP),intent(out)  :: globalMaxCFLInterf
+	  logical, optional          :: onlyRoot
 #ifdef FLOW
       !------------------------------------------------
       integer                       :: i, j, k, eID                     ! Coordinate and element counters
@@ -900,7 +1056,8 @@ Module DGSEMClass
       real(kind=RP)                 :: Q(NCONS)                         ! The conservative variable
       real(kind=RP)                 :: cfl                              ! cfl - Advective
 	  real(kind=RP)                 :: maxCFL, minCFL, maxCFLInterface
-	  real(kind=RP), allocatable    :: elementCFL(:), maxCFLInterfaceID(:)                         
+	  real(kind=RP), allocatable    :: elementCFL(:), maxCFLInterfaceID(:)              
+      logical                       :: isRootOnly	  
       type(NodalStorage_t), pointer :: spAxi_p, spAeta_p, spAzeta_p     ! Pointers to the nodal storage in every direction
       external                      :: ComputeEigenvaluesForState       ! Advective eigenvalue
 #if defined(INCNS) || defined(MULTIPHASE)
@@ -914,6 +1071,13 @@ Module DGSEMClass
 !--------------------------------------------------------
 !     Initializations
 !     ---------------
+
+	  if (present(onlyRoot)) then
+	     isRootOnly = onlyRoot
+      else
+		 isRootOnly = .false.
+	  end if 
+		 
 	  allocate(elementCFL(1:SIZE(self % mesh % elements)), maxCFLInterfaceID(1:SIZE(self % mesh % elements)))
 	  maxCFLInterfaceID(:) = 0.0_RP
 
@@ -1020,7 +1184,7 @@ Module DGSEMClass
 
 #ifdef _HAS_MPI_
 
-      if ( MPI_Process % doMPIAction ) then
+      if ( ( MPI_Process % doMPIAction ).and.(.not.isRootOnly)) then
 	     call mpi_allreduce(maxCFL, globalMax, 1, MPI_DOUBLE, MPI_MAX, &
                             MPI_COMM_WORLD, ierr)
 		 call mpi_allreduce(maxCFLInterface, globalMaxCFLInterf, 1, MPI_DOUBLE, MPI_MAX, &
@@ -1031,7 +1195,8 @@ Module DGSEMClass
       end if
 #endif
 
-#endif
+#endif	  
+
    end subroutine DetermineCFL
 !
 !////////////////////////////////////////////////////////////////////////

--- a/Solver/src/libs/foundation/Utilities.f90
+++ b/Solver/src/libs/foundation/Utilities.f90
@@ -21,7 +21,7 @@ module Utilities
    public   AlmostEqual, UnusedUnit, SolveThreeEquationLinearSystem, GreatestCommonDivisor, outer_product, AlmostEqualRelax
    public   toLower, Qsort, QsortWithFriend, BubblesortWithFriend, my_findloc, sortAscend, sortDescendInt, sortAscendInt
    public   logarithmicMean, dot_product
-   public   LeastSquaresLinRegression
+   public   LeastSquaresLinRegression, reindexIntegerList, combine_partitions, log_mem
    
    interface dot_product
       module procedure dot_product_3Tensor_Vec
@@ -583,6 +583,166 @@ pure subroutine sortDescendInt(A,B)
 end subroutine sortDescendInt
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+! Subroutine to reindexIntegerList as such it is compactly renumbered from 0 to totalNodes-1 (for METIS operation in MLRK reconstruct)
+!///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+!
+subroutine reindexIntegerList(Node, totalNodes, oldID)
+    implicit none
+    integer, intent(inout) :: Node(:)           ! Array to reindex (modified in place)
+    integer, intent(out)   :: totalNodes        ! Total unique nodes after reindexing
+    integer, allocatable, intent(out) :: oldID(:)      ! Map: newID -> original value
+
+    ! Internals
+    integer, allocatable :: map_old_to_new(:)
+    integer              :: i, counter, max_val, nVertexSize
+    logical, allocatable :: seen(:)
+	
+	nVertexSize = size(Node)
+
+    ! Find maximum value in the input Node array
+    max_val = maxval(Node)
+
+    ! Allocate helper arrays
+    allocate(seen(0:max_val))
+    seen = .false.
+
+    ! Mark which values are used
+    do i = 1, nVertexSize
+      seen(Node(i)) = .true.
+    end do
+
+    ! Count unique values and allocate map
+    totalNodes = count(seen)
+    allocate(map_old_to_new(0:max_val))
+    allocate(oldID(1:totalNodes))
+
+    ! Assign new compact IDs and build reverse map
+    counter = 0
+    do i = 0, max_val
+      if (seen(i)) then
+        map_old_to_new(i) = counter
+        oldID(counter+1) = i+1
+        counter = counter + 1
+      end if
+    end do
+
+    ! Replace old values in Node with new compact IDs
+    do i = 1, nVertexSize
+      Node(i) = map_old_to_new(Node(i))
+    end do
+
+    ! Cleanup
+    deallocate(seen, map_old_to_new)
+end subroutine reindexIntegerList
+!
+!//////////////////////////////////////////////////////////////////////////////////////
+! Subroutine to combine_partitions between MLRK levels as such it has minimum MPI faces
+!//////////////////////////////////////////////////////////////////////////////////////
+!
+subroutine combine_partitions(nElement, nLevel, nPartition, refMap, inputMap, finalMap)
+    implicit none
+    integer, intent(in) :: nElement, nLevel, nPartition
+    integer, intent(in) :: refMap(nElement)
+    integer, intent(in) :: inputMap(nElement, nLevel)
+    integer, intent(out):: finalMap(nElement)
+
+    integer :: i, l, label, refLabel, indexOrderMax(nPartition)
+    integer, allocatable :: levelMap(:), newMap(:,:), matchCount(:,:)
+    integer :: bestLabel, maxMatch
+    logical, allocatable :: used(:)
+
+    allocate(levelMap(nElement))
+    allocate(newMap(nPartition, nLevel))
+    allocate(matchCount(nPartition, nPartition))
+    allocate(used(nPartition))
+
+    finalMap = 0
+    newMap = 0
+
+    do l = 1, nLevel
+        matchCount = 0
+        ! Count matches between each input label and reference label
+        do i = 1, nElement
+            if (inputMap(i,l) > 0) then
+                label = inputMap(i,l)
+                refLabel = refMap(i)
+                matchCount(label, refLabel) = matchCount(label, refLabel) + 1
+            end if
+        end do
+		
+		call SortRowIndicesByRowMaxDescending(nPartition, matchCount, indexOrderMax)
+
+        ! For each label, find the best matching refMap label
+        used = .false.
+        do i = 1, nPartition
+		    label = indexOrderMax(i)
+            maxMatch = -1
+            bestLabel = 0
+            do refLabel = 1, nPartition
+                if (.not. used(refLabel)) then
+                    if (matchCount(label, refLabel) > maxMatch) then
+                        maxMatch = matchCount(label, refLabel)
+                        bestLabel = refLabel
+                    end if
+                end if
+            end do
+            if (bestLabel > 0) then
+                newMap(label,l) = bestLabel
+                used(bestLabel) = .true.
+            else
+                newMap(label,l) = label
+            end if
+        end do
+    end do
+
+    ! Build finalMap using relabeled inputMap
+    do i = 1, nElement
+        do l = 1, nLevel
+            if (inputMap(i,l) > 0) then
+                finalMap(i) = newMap(inputMap(i,l), l)
+                exit
+            end if
+        end do
+    end do
+	
+    deallocate(levelMap, newMap, matchCount, used)
+	
+end subroutine combine_partitions
+
+Subroutine SortRowIndicesByRowMaxDescending(m, A, row_order)
+  implicit none
+  integer, intent(in) :: m
+  integer, intent(in) :: A(m, m)
+  integer, intent(out) :: row_order(m)
+
+  integer :: i, j, tmp_idx, tmp_val
+  integer :: row_max(m)
+
+  ! Compute max value for each row
+  do i = 1, m
+     row_max(i) = maxval(A(i, :))
+     row_order(i) = i
+  end do
+
+  ! Sort row_order based on descending row_max values
+  do i = 1, m-1
+     do j = i+1, m
+        if (row_max(i) < row_max(j)) then
+           ! Swap max values
+           tmp_val = row_max(i)
+           row_max(i) = row_max(j)
+           row_max(j) = tmp_val
+           ! Swap row indices
+           tmp_idx = row_order(i)
+           row_order(i) = row_order(j)
+           row_order(j) = tmp_idx
+        end if
+     end do
+  end do
+end subroutine SortRowIndicesByRowMaxDescending
+
+!
+!///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
 integer function my_findloc(arr, val, dim)
 !  ---------------------------------------------------------
@@ -610,4 +770,29 @@ integer function my_findloc(arr, val, dim)
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
+    subroutine log_mem(tag)
+        ! Logs current memory usage (VmRSS) and timestamp with a custom tag
+        character(*), intent(in) :: tag
+        character(len=256) :: line
+        integer :: unit, ios
+        integer :: vals(8)
+        character(len=20) :: timestr
+
+        ! Get time for correlation
+        call date_and_time(values=vals)
+		write(timestr, '(I2.2,":",I2.2,":",I2.2,".",I3.3)') vals(5), vals(6), vals(7), vals(8)
+
+        ! Read /proc/self/status for VmRSS
+        open(newunit=unit, file="/proc/self/status", status="old", action="read", iostat=ios)
+        if (ios /= 0) return
+        do
+            read(unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            if (line(1:6) == 'VmRSS:') then
+                print '(A,1X,A,1X,A)', timestr, trim(tag), trim(line)
+                exit
+            end if
+        end do
+        close(unit)
+    end subroutine log_mem
 end module Utilities

--- a/Solver/src/libs/mesh/HexElementClass.f90
+++ b/Solver/src/libs/mesh/HexElementClass.f90
@@ -66,8 +66,9 @@
          INTEGER                         :: nodeIDs(8)
          integer                         :: faceIDs(6)
          integer                         :: faceSide(6)
-		   integer                         :: MLevel            ! RK Level
-		   real(kind=RP)                   :: ML_CFL            ! CFL storage for Multi Level RK	
+		 integer                         :: MLevel            ! RK Level
+		 integer                         :: MLevelwN          ! RK Level with Neighbour
+		 real(kind=RP)                   :: ML_CFL            ! CFL storage for Multi Level RK	
          real(kind=RP)                   :: ML_error_ratio    ! Ratio between temporal and spatial error relative to the global ratio
          INTEGER, DIMENSION(3)           :: Nxyz              ! Polynomial orders in every direction (Nx,Ny,Nz)
          real(kind=RP)                   :: hn                ! Ratio of size and polynomial order
@@ -125,7 +126,7 @@
          self % boundaryName        = emptyBCName
          self % hasSharedFaces      = .false.
          self % NumberOfConnections = 0
-		   self % MLevel              = 1
+		 self % MLevel              = 1
          self % ML_error_ratio      = 1.0_RP
 !
 !        ----------------------------------------

--- a/Solver/src/libs/mesh/METISPartitioning.f90
+++ b/Solver/src/libs/mesh/METISPartitioning.f90
@@ -1,4 +1,5 @@
-subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesDomain, useWeights, controlVariables)
+subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesDomain, useWeights, controlVariables, &
+										nLevel, eID_Order, nElementLevel)
 !
 !     *********************************************************************
 !        This subroutine performs the mesh partitioning using METIS
@@ -9,6 +10,7 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
       use SMConstants
       use MPI_Process_Info
       use FTValueDictionaryClass
+	  use Utilities                   , only : reindexIntegerList, combine_partitions
       implicit none
       type(HexMesh), intent(in)              :: mesh
       integer,       intent(in)              :: no_of_domains
@@ -16,12 +18,15 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
       integer,       intent(out)             :: nodesDomain(size(mesh % nodes))
       logical,       intent(in)              :: useWeights
       type(FTValueDictionary), intent(in)    :: controlVariables
+	  integer,       intent(in)              :: nLevel 
+	  integer,       intent(in)      	     :: eID_Order(mesh % no_of_elements)
+	  integer,       intent(in)      	     :: nElementLevel(nLevel)
 !
 !     ---------------
 !     Local Variables
 !     ---------------
 !
-      integer                :: i, j, domain_id
+      integer                :: i, j, domain_id, level, starteID
       integer                :: ielem
       integer                :: ne                    ! # elements
       integer                :: nn                    ! # nodes
@@ -29,10 +34,10 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
       integer, allocatable   :: eptr(:)               ! index in eind --> eptr(ne+1)
       integer, allocatable   :: eind(:)               ! vertices of each element   --> eind(nvertex*ne)
       integer, pointer       :: vwgt(:) => null()     ! vertices weights
-      integer, pointer       :: vsize(:) => null()    !
+      integer, allocatable   :: vsize(:) 
       integer, parameter     :: ncommon = 4           ! common faces for dual nesh (4 for hexahedrals)
-      real(kind=RP), pointer :: tpwgt(:) => null()    ! partitions' weights --> tpwgt(no_of_domains)
-      integer, pointer       :: opts(:) => null()     ! metis options
+      real(kind=RP), allocatable  :: tpwgt(:)         ! partitions' weights --> tpwgt(no_of_domains)
+      integer, allocatable   :: opts(:)               ! metis options
       integer, parameter     :: metis_noptions = 39   ! number of metis options
       integer                :: objval                ! objective calculated value
       integer, parameter     :: MIN_EDGE_CUT = -1     ! option to minimize edge-cut
@@ -45,6 +50,9 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
       integer                :: target_water, target_air, w_idx, a_idx
       logical, allocatable   :: elem_moved(:)
       logical                :: do_water_air_count    ! Flag to control water/air counting
+	  integer, allocatable   :: elementsDomainLevel(:), nodesDomainLevel(:), mapToOld(:)
+	  integer, allocatable   :: refEleDomain(:), inputMLRKDomain(:,:)
+	  
 #ifdef _HAS_METIS_
 !
 !     **************
@@ -54,7 +62,10 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
       ne = mesh % no_of_elements
       nn = size(mesh % nodes)
       nvertex = 8
-
+	  
+	  allocate(inputMLRKDomain(mesh % no_of_elements, nLevel))
+	  inputMLRKDomain = 0
+	
       ! Check if we should do water/air counting based on explicit method
       do_water_air_count = .false.
       if(trim(controlVariables % stringValueForKey('explicit method', requestedLength = LINE_LENGTH)) == 'MixedRK') then
@@ -83,91 +94,207 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
               write(*,'(A,I6,A,I6,A)') 'Identified ', water_count, ' water elements and ', air_count, ' air elements'
           end if
       end if
+!
+!     Construct the reference element partition from single level for MLRK
+!     --------------------------------------------------------------------      
+	  if (nLevel.gt.1) then
+	    allocate(refEleDomain(ne))
+		allocate(eptr(ne+1), eind(nvertex*ne))
+		
+		refEleDomain    =0
+!
+!     	Gather each element nodes: they are stored using C indexes (starting on 0)
+!     	-------------------------
+		i = 1
+		do ielem=1,ne
+!
+!        	Save each element nodes
+!        	-----------------------
+			eind(i:i+nvertex-1) = mesh % elements(ielem) % nodeIDs - 1
+!
+!        	Save each element ID
+!        	--------------------
+			eptr(ielem) = i - 1
+			i = i + nvertex
+		end do
+!
+!     	Termination: set the last element position in the N+1 entry
+!     	-----------
+		eptr(ne+1) = i - 1
+!
+!     	*****************
+!     	Set METIS options
+!     	*****************
+!
+		allocate(opts(0:metis_noptions))
+		call METIS_SetDefaultOptions(opts)
+!
+!     	First option chooses the method: edge-cut / communication volume      
+!     	-------------------------------
+		opts(1) = MIN_EDGE_CUT
+!
+!     	Disable verbosity
+!     	-----------------
+		opts(5) = 0
+!
+!     	*******************************
+!     	Calculate weights based on NDOF
+!     	*******************************
+!
+		if (useWeights) then
+		  allocate(weights(ne))
+		  do ielem=1,ne
+			  ! Base weight from polynomial order
+			  weights(ielem) = product(mesh % elements(ielem) % Nxyz + 1)
+		  end do
+		  if (maxval(weights) .ne. minval(weights)) then
+			  vwgt => weights
+		  endif
+		end if 
+	    
+		call METIS_PartMeshDual(ne, nn,  eptr, eind,  vwgt, vsize, ncommon, no_of_domains, tpwgt,  opts,  objval, refEleDomain, nodesDomain)
+!
+!     	Recover FORTRAN displacements by adding 1
+!     	-----------------------------------------
+		refEleDomain = refEleDomain + 1
+!
+!       Free memory
+!       -----------
+!
+		deallocate (eptr, eind, opts)
+		if (associated(vwgt)) nullify(vwgt)       ! vwgt is a pointer to a target. nullify is enough
+		if (allocated(weights)) deallocate(weights)
+		if (allocated(tpwgt)) deallocate(tpwgt)
+		if (allocated(vsize)) deallocate(vsize)
+	  end if 
+!
+!     Perform METIS partitioning based on the element's level - if not MLRK then nLevel=1
+!     -----------------------------------------------------------------------------------
+	  starteID = 1								   ! counter of the elementID for multi level 
+	  do level =1, nLevel
+		ne = nElementLevel(level)
+		allocate(eptr(ne+1))
+		allocate(eind(nvertex*ne))
+!
+!     	Gather each element nodes: they are stored using C indexes (starting on 0)
+!     	-------------------------------------------------------------------------
+		i = 1
+		j = 0
+		do ielem=starteID, ne+starteID-1
+		    j=j+1
+!
+!        	Save each element nodes
+!        	-----------------------
+			eind(i:i+nvertex-1) = mesh % elements(eID_Order(ielem)) % nodeIDs - 1
+!
+!        	Save each element ID
+!        	--------------------
+			eptr(j) = i - 1
+			i = i + nvertex
+		end do
+!
+!     	reindexIntegerList as such it is compactly renumbered from 0 to totalNodes-1
+!     	----------------------------------------------------------------------------
+        allocate(mapToOld(size(mesh % nodes)))
+		mapToOld = [(i, i=1,size(mesh % nodes))]
+		if (nLevel.gt.1) then
+		    deallocate(mapToOld)
+			call reindexIntegerList(eind,nn,mapToOld)
+		end if
+		allocate(elementsDomainLevel(1:ne), nodesDomainLevel(1:nn))
+!
+!     	Termination: set the last element position in the N+1 entry
+!     	-----------------------------------------------------------
+		eptr(ne+1) = i - 1
+!
+!     	*****************
+!     	Set METIS options
+!     	*****************
+!
+		allocate(opts(0:metis_noptions))
+		call METIS_SetDefaultOptions(opts)
+!
+!     	First option chooses the method: edge-cut / communication volume      
+!     	----------------------------------------------------------------
+		opts(1) = MIN_EDGE_CUT
+!
+!     	Disable verbosity
+!     	-----------------
+		opts(5) = 0
+!
+!     	*******************************
+!     	Calculate weights based on NDOF
+!     	*******************************
+!
+		if (useWeights) then
+		  allocate(weights(ne))
+		  do ielem=1,ne
+			  ! Base weight from polynomial order
+			  weights(ielem) = product(mesh % elements(eID_Order(ielem+starteID-1)) % Nxyz + 1)
+			  
+			  ! Determine if this is a water element and apply weight factor only if needed
+			  if (do_water_air_count) then
+				  is_water = .false.
+				  if (associated(mesh % elements(eID_Order(ielem+starteID-1)) % storage)) then
+						  is_water = all(mesh % elements(eID_Order(ielem+starteID-1)) % storage % Q(1,:,:,:) < 1.0_RP - 1e-8_RP) 
+				  end if
+				  
+				  ! Apply 4.666x weight factor for water elements
+				  ! Not fully necessary because of the manual air-watter balancing done later in the function
+				  ! but this is to protect against edge cases
+				  if (is_water) then
+					  weights(ielem) = weights(ielem) * 4.6666
+				  end if
+			  end if
+		  end do
 
-      allocate(eptr(ne+1))
-      allocate(eind(nvertex*ne))
+		  if (maxval(weights) .ne. minval(weights)) then
+			  vwgt => weights
+		  endif
+		end if 
+!     	**********************
+!     	Perform the partitions
+!     	**********************
 !
-!     Gather each element nodes: they are stored using C indexes (starting on 0)
-!     -------------------------
-      i = 1
-      do ielem=1,ne
+		call METIS_PartMeshDual(ne, nn,  eptr, eind,  vwgt, vsize, ncommon, no_of_domains, tpwgt,  opts,  objval, elementsDomainLevel, nodesDomainLevel)
 !
-!        Save each element nodes
-!        -----------------------
-         eind(i:i+nvertex-1) = mesh % elements(ielem) % nodeIDs - 1
+!     	Recover FORTRAN displacements by adding 1
+!     	-----------------------------------------
+		elementsDomainLevel = elementsDomainLevel + 1
+		nodesDomainLevel    = nodesDomainLevel + 1
 !
-!        Save each element ID
-!        --------------------
-         eptr(ielem) = i - 1
-         i = i + nvertex
-      end do
+!     	Send information to inputMLRKDomain - relocate to true elementID
+!     	----------------------------------------------------------------
+        do i=1, ne
+			inputMLRKDomain(eID_Order(starteID+i-1), level) = elementsDomainLevel(i)
+		end do 
+		starteID = starteID + ne
 !
-!     Termination: set the last element position in the N+1 entry
-!     -----------
-      eptr(ne+1) = i - 1
+!       Free memory
+!       -----------
 !
-!     *****************
-!     Set METIS options
-!     *****************
+		deallocate (nodesDomainLevel, elementsDomainLevel, mapToOld, eptr, eind, opts)
+		if (associated(vwgt)) 	nullify(vwgt)       ! vwgt is a pointer to a target. nullify is enough
+		if (allocated(weights)) deallocate(weights)
+		if (allocated(tpwgt)) 	deallocate(tpwgt)
+		if (allocated(vsize)) 	deallocate(vsize)
+	 end do
+	 
+	 nodesDomain = 0 ! Not used 
+	 do i=1, mesh % no_of_elements
+		elementsDomain(i) = sum(inputMLRKDomain(i,:))
+	 end do 
 !
-      allocate(opts(0:metis_noptions))
-      call METIS_SetDefaultOptions(opts)
-!
-!     First option chooses the method: edge-cut / communication volume      
-!     -------------------------------
-      opts(1) = MIN_EDGE_CUT
-!
-!     Disable verbosity
-!     -----------------
-      opts(5) = 0
-!
-!     *******************************
-!     Calculate weights based on NDOF
-!     *******************************
-!
-      if (useWeights) then
-          allocate(weights(ne))
-          do ielem=1,ne
-              ! Base weight from polynomial order
-              weights(ielem) = product(mesh % elements(ielem) % Nxyz + 1)
-              
-              ! Determine if this is a water element and apply weight factor only if needed
-              if (do_water_air_count) then
-                  is_water = .false.
-                  if (associated(mesh % elements(ielem) % storage)) then
-                          is_water = all(mesh % elements(ielem) % storage % Q(1,:,:,:) < 1.0_RP - 1e-8_RP) 
-                  end if
-                  
-                  ! Apply 4.666x weight factor for water elements
-                  ! Not fully necessary because of the manual air-watter balancing done later in the function
-                  ! but this is to protect against edge cases
-                  if (is_water) then
-                      weights(ielem) = weights(ielem) * 4.6666
-                  end if
-              end if
-          end do
-          ! weights(ne+1) = product(mesh % elements(ielem) % Nxyz + 1)
-          ! eptr(ne+1) = i - 1
-          if (maxval(weights) .ne. minval(weights)) then
-              vwgt => weights
-          endif
-      end if 
-!     **********************
-!     Perform the partitions
-!     **********************
-!
-      call METIS_PartMeshDual(ne, nn,  eptr, eind,  vwgt, vsize, ncommon, no_of_domains, tpwgt,  opts,  objval, elementsDomain, nodesDomain)
-!
-!     Recover FORTRAN displacements by adding 1
-!     -----------------------------------------
-      elementsDomain = elementsDomain + 1
-      nodesDomain = nodesDomain + 1
-
-!     ************************************
-!     Manual balancing of water and air. 
-!     The aim is to have equal number of air and water elements in each core.
-!     ************************************
-      if (do_water_air_count .and. water_count > 0 .and. air_count > 0) then
+!    Combine_partitions between MLRK levels as such it has minimum MPI faces
+!    -----------------------------------------------------------------------
+	 if (nLevel.gt.1) then
+		call combine_partitions(mesh % no_of_elements, nLevel, no_of_domains, refEleDomain, inputMLRKDomain, elementsDomain)
+	 end if 
+!    ************************************
+!    Manual balancing of water and air. 
+!    The aim is to have equal number of air and water elements in each core.
+!    ************************************
+     if (do_water_air_count .and. water_count > 0 .and. air_count > 0) then
           ! Allocate arrays for balancing
           allocate(domain_water_count(no_of_domains), domain_air_count(no_of_domains))
           allocate(water_elems(water_count), air_elems(air_count))
@@ -261,7 +388,10 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
                   nodesDomain(mesh % elements(ielem) % nodeIDs(i)) = elementsDomain(ielem)
               end do
           end do
-          
+!
+!         Free memory
+!         -----------
+!
           deallocate(domain_water_count, domain_air_count)
           deallocate(water_elems, air_elems)
           deallocate(elem_moved)
@@ -269,12 +399,12 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
           if (MPI_Process % isRoot) then
               write(*,*) "Applied post-processing to balance water/air elements"
           end if
-      end if
+	  end if
 
 !     **********************
 !     Print domain statistics
 !     **********************
-      if (do_water_air_count .and. MPI_Process % isRoot) then
+	  if (do_water_air_count .and. MPI_Process % isRoot) then
           do domain_id = 1, no_of_domains
               water_count = 0
               air_count = 0
@@ -299,15 +429,14 @@ subroutine GetMETISElementsPartition(mesh, no_of_domains, elementsDomain, nodesD
                     ', Air elements = ', air_count, &
                     ', Total = ', water_count + air_count
           end do
-      end if
+	  end if
 !
 !     ****
 !     Free
 !     ****
 !
-      deallocate(eptr)
-      deallocate(eind)
       if (allocated(weights)) deallocate(weights)
-      if (associated(opts)) deallocate(opts)
+	  if (allocated(inputMLRKDomain)) deallocate(inputMLRKDomain)
+	  if (allocated(refEleDomain)) deallocate(refEleDomain)
 #endif
    end subroutine GetMETISElementsPartition

--- a/Solver/src/libs/mesh/OrientedBoundingBox.f90
+++ b/Solver/src/libs/mesh/OrientedBoundingBox.f90
@@ -846,6 +846,8 @@ contains
          Hull% Points(i) = p
          p => p% next
       end do
+	  
+	  nullify(p, p1)
          
       call convPoints% destruct()
 

--- a/Solver/src/libs/mesh/SurfaceMesh.f90
+++ b/Solver/src/libs/mesh/SurfaceMesh.f90
@@ -917,6 +917,7 @@ Module SurfaceMesh
 !    Close the file
 !    --------------
      call SealSolutionFile(trim(name))
+	 nullify(f)
 !
    End Subroutine SurfaceSaveSolution
 !         
@@ -1126,6 +1127,7 @@ Module SurfaceMesh
 !     Free memory
 !     -----------
       deallocate(facesSizes, allfacesSizes, allFacesOffset)
+	  nullify(faces)
 !
    End Subroutine SurfacePrepareForIO
 !

--- a/Solver/src/libs/mesh/ZoneClass.f90
+++ b/Solver/src/libs/mesh/ZoneClass.f90
@@ -22,6 +22,7 @@ module ZoneClass
       contains
          procedure   :: Initialize       => Zone_Initialize
          procedure   :: copy             => Zone_Assign
+		 procedure   :: destruct         => Zone_Destruct
          generic     :: assignment(=)    => copy
          procedure   :: CreateFictitious => Zone_CreateFictitious
    end type Zone_t
@@ -73,6 +74,7 @@ module ZoneClass
          call ConstructBoundaryConditions(no_of_markers, zoneNames)
          
          deallocate (zoneNames)
+		 nullify(zoneNames)
       end subroutine ConstructZones
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -113,6 +115,7 @@ module ZoneClass
          call Zone_AssignFaces(faces,zones,no_of_markers,zoneNames)
          
          deallocate (zoneNames)
+		 nullify(zoneNames)
       end subroutine ReassignZones
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -131,6 +134,16 @@ module ZoneClass
          self % no_of_faces = 0
 
       end subroutine Zone_Initialize
+!     ------------------------------------------
+!     Destruct Zone
+!     ------------------------------------------	  
+      subroutine Zone_Destruct ( self) 
+         implicit none
+         class(Zone_t)           :: self
+
+         safedeallocate(self % faces)
+
+      end subroutine Zone_Destruct
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !

--- a/Solver/src/libs/monitors/Monitors.f90
+++ b/Solver/src/libs/monitors/Monitors.f90
@@ -85,6 +85,7 @@ module MonitorsClass
          character(len=STR_LEN_MONITORS) :: solution_file                                            
          logical, save                   :: FirstCall = .TRUE.
          logical                         :: saveGradients
+		 logical                         :: monitorMem =.FALSE.
 !
 !        Setup the buffer
 !        ----------------
@@ -96,6 +97,12 @@ module MonitorsClass
                     Monitors % SolverSimuTime(BUFFER_SIZE), &
                     Monitors % t(BUFFER_SIZE), &
                     Monitors % iter(BUFFER_SIZE) )
+!
+!        Memory Monitor
+!        ---------------------
+         if ( controlVariables % ContainsKey("monitor memory") ) then
+			monitorMem = controlVariables % LogicalValueForKey ("monitor memory")
+		 end if 
 !
 !        Get the solution file name
 !        --------------------------
@@ -119,7 +126,7 @@ module MonitorsClass
 !
 !        Initialize
 !        ----------
-         call Monitors % residuals % Initialization( solution_file , FirstCall )
+         call Monitors % residuals % Initialization( solution_file , FirstCall, monitorMem)
 
          allocate ( Monitors % volumeMonitors ( Monitors % no_of_volumeMonitors )  )
          do i = 1 , Monitors % no_of_volumeMonitors
@@ -250,6 +257,12 @@ module MonitorsClass
          do i = 1 , NCONS
             write(STD_OUT , '(3X,A10)' , advance = "no" ) trim(dashes)
          end do
+!
+!        Print dashes for memory
+!        --------------------------
+         if (self % residuals % memory) then
+            write(STD_OUT , '(3X,A10)' , advance = "no" ) trim(dashes)
+         end if
 !
 !        Print dashes for volume monitors
 !        --------------------------------

--- a/Solver/src/libs/monitors/ResidualsMonitor.f90
+++ b/Solver/src/libs/monitors/ResidualsMonitor.f90
@@ -5,6 +5,9 @@ module ResidualsMonitorClass
    use HexMeshClass
    use MonitorDefinitions
    use MPI_Process_Info
+#ifdef _HAS_MPI_
+      use mpi
+#endif
    implicit none
    
    private
@@ -19,6 +22,8 @@ module ResidualsMonitorClass
       real(kind=RP), allocatable      :: values(:,:)
       real(kind=RP), allocatable      :: CPUtime(:)
       character(len=STR_LEN_MONITORS) :: fileName
+	  logical                         :: memory =.FALSE.
+	  real(kind=RP), allocatable      :: totMemory(:)
       contains
          procedure   :: Initialization => Residuals_Initialization
          procedure   :: Update         => Residuals_Update
@@ -40,16 +45,17 @@ module ResidualsMonitorClass
 !           ------------------
 !//////////////////////////////////////////////////////////////////////////////////////////////////
 !
-      subroutine Residuals_Initialization( self, solution_file, FirstCall ) 
+      subroutine Residuals_Initialization( self, solution_file, FirstCall, monitorMem ) 
 !
 !        *******************************************************************
 !              This subroutine initializes the residuals structure
 !        *******************************************************************
 !
          implicit none
-         class(Residuals_t) :: self
-         character(len=*)   :: solution_file
+         class(Residuals_t)  :: self
+         character(len=*)    :: solution_file
          logical, intent(in) :: FirstCall
+		 logical, intent(in) :: monitorMem
 !
 !        ---------------
 !        Local variables
@@ -68,31 +74,41 @@ module ResidualsMonitorClass
 !        ---------------------
          write( self % fileName , '(A,A)') trim(solution_file) , ".residuals"  
 !
+!        Memory Monitor
+!        ---------------------
+		 self % memory = monitorMem
+		 if (self % memory) then
+			allocate( self % totMemory(BUFFER_SIZE))
+			self % totMemory = 0.0_RP
+		 end if 
+!
 !        Create file to write the residuals
 !        ----------------------------------
          if (FirstCall) then
             open ( newunit = fID , file = trim(self % fileName) , status = "unknown" , action = "write" ) 
             write ( fID , ' ( A                                      ) ' ) "#Residuals file"
 #if defined(NAVIERSTOKES) && (!(SPALARTALMARAS))
-            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' ) "#Iteration" , "Time" , &
+            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' , advance = "no") "#Iteration" , "Time" , &
                         "Total elapsed Time (s)", "Solver elapsed Time (s)" , "continuity" , "x-momentum" , "y-momentum" , "z-momentum", "energy" , "Max-Residual"
 #elif defined(SPALARTALMARAS)
-            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' ) "#Iteration" , "Time" , &
+            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' , advance = "no") "#Iteration" , "Time" , &
                         "Total elapsed Time (s)", "Solver elapsed Time (s)" , "continuity" , "x-momentum" , "y-momentum" , "z-momentum", "energy" ," Turbulence Param" , "Max-Residual"
 #elif defined(INCNS)
-            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' ) "#Iteration" , "Time" , &
+            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' , advance = "no") "#Iteration" , "Time" , &
                         "Elapsed Time (s)" , "dens-transp" , "x-momentum" , "y-momentum" , "z-momentum", "div-v" , "Max-Residual"
 #elif defined(MULTIPHASE)
-            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' ) "#Iteration" , "Time" , &
-                        "Elapsed Time (s)" , "concentration" , "x-momentum" , "y-momentum" , "z-momentum", "div-v" , "Max-Residual"
+            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' , advance = "no") "#Iteration" , "Time" , &
+                        "Elapsed Time (s)", "Solver elapsed Time (s)" , "concentration" , "x-momentum" , "y-momentum" , "z-momentum", "div-v" , "Max-Residual"
 #elif defined(CAHNHILLIARD)
-            write ( fID , ' ( A10,2X,A24,2X,A24) ' ) "#Iteration" , "Time" , "concentration"
+            write ( fID , ' ( A10,2X,A24,2X,A24) ' , advance = "no") "#Iteration" , "Time" , "concentration"
 
 #elif defined(ACOUSTIC)
-            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ' ) "#Iteration" , "Time" , &
+            write ( fID , ' ( A10,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24,2X,A24 ) ', advance = "no" ) "#Iteration" , "Time" , &
                         "Elapsed Time (s)" , "density" , "x-velocity" , "y-velocity" , "z-velocity", "pressure" , "Max-Residual"
 
 #endif
+			if (self % memory) write ( fID , ' ( 2X,A24 ) ', advance = "no") "Total Memory(kB)" 
+			write ( fID , '(2X)')
 !
 !        Close file
 !        ----------
@@ -113,9 +129,46 @@ module ResidualsMonitorClass
          real(kind=RP)              :: maxResiduals(NCONS)
          integer                    :: bufferPosition
 !
+!        ---------------
+!        Local variables
+!        ---------------
+!
+		 integer 					:: fID, ios
+		 integer                    :: ierr 
+		 real(kind=RP) 				:: mem_kb
+		 character(len=256) 		:: line
+!
 !        Update buffer values
 !        --------------------      
          self % values( 1:NCONS, bufferPosition ) = maxResiduals
+!
+!        Get total memory
+!        --------------------   
+		 if (.not. self % memory) return
+		 
+		! Default to 0 in case parsing fails
+		 mem_kb = 0.0d0
+
+		! Open /proc/self/status and read VmRSS
+		open(newunit=fID, file="/proc/self/status", status="old", action="read", iostat=ios)
+		if (ios == 0) then
+			do
+				read(fID, '(A)', iostat=ios) line
+				if (ios /= 0) exit
+				if (line(1:6) == 'VmRSS:') then
+					read(line(7:), *, iostat=ios) mem_kb
+					exit
+				end if
+			end do
+			close(fID)
+		end if
+		self % totMemory(bufferPosition) = mem_kb
+#ifdef _HAS_MPI_
+		if (MPI_Process % doMPIAction) then
+			! Reduce memory usage across all ranks
+			call MPI_Allreduce(mem_kb, self % totMemory(bufferPosition), 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+		end if
+#endif
 
       end subroutine Residuals_Update
 
@@ -161,8 +214,10 @@ module ResidualsMonitorClass
          write(STD_OUT , '(3X,A10)' , advance = "no") "y-velocity"
          write(STD_OUT , '(3X,A10)' , advance = "no") "z-velocity"
          write(STD_OUT , '(3X,A10)' , advance = "no") "pressure"
-
 #endif
+		if (self % memory) then 
+			write(STD_OUT , '(3X,A10)' , advance = "no") "memory(kB)"
+		end if 
 
       end subroutine Residuals_WriteLabel
    
@@ -182,6 +237,9 @@ module ResidualsMonitorClass
          do eq = 1 , NCONS
             write(STD_OUT , '(1X,A,1X,ES10.3)' , advance = "no") "|" , self % values(eq , bufferLine)
          end do
+		if (self % memory) then 
+			write(STD_OUT , '(1X,A,1X,ES10.3)' , advance = "no") "|" , self % totMemory(bufferLine)
+		end if 
 
       end subroutine Residuals_WriteValue 
 
@@ -216,7 +274,13 @@ module ResidualsMonitorClass
 !           ------------
             do i = 1 , no_of_lines
                write(fID, '(I10,3(2X,ES24.16))', advance="no") iter(i), t(i), TotalSimuTime(i), SolverSimuTime(i)
-               write(fID, 111) self % values(1:NCONS,i), maxval(self % values(1:NCONS,i))
+               
+			   if (self % memory) then 
+					write(fID, 111, advance = "no") self % values(1:NCONS,i), maxval(self % values(1:NCONS,i))
+					write(fID , '(2X,ES16.8)') self % totMemory(i)
+			   else
+					write(fID, 111) self % values(1:NCONS,i), maxval(self % values(1:NCONS,i))
+			   end if 
             end do
 !
 !           Close file
@@ -227,6 +291,9 @@ module ResidualsMonitorClass
 
          if ( no_of_lines .ne. 0 ) then
             self % values(1:NCONS,1) = self % values(1:NCONS,no_of_lines)
+			if (self % memory) then 
+				self % totMemory(1)      = self % totMemory(no_of_lines)
+			end if
          end if
 
 #if defined(FLOW)
@@ -242,8 +309,10 @@ module ResidualsMonitorClass
          
          safedeallocate (self % values)
          safedeallocate (self % CPUtime)
+		 safedeallocate (self % totMemory)
          self % fileName = ""
          self % active   = .FALSE.
+		 self % memory   = .FALSE.
          
       end subroutine Residuals_Destruct
       
@@ -261,8 +330,16 @@ module ResidualsMonitorClass
          safedeallocate (to % CPUtime)
          allocate ( to % CPUtime( size(from % CPUtime) ) )
          to % CPUtime = from % CPUtime
+		 
+		 safedeallocate (to % totMemory)
+		 if (allocated(from % totMemory)) then
+			allocate ( to % totMemory( size(from % totMemory) ) )
+			to % totMemory = from % totMemory
+	     end if 
          
          to % fileName = from % fileName
+		 
+		 to % memory = from % memory
          
       end subroutine Residuals_Assign
 end module ResidualsMonitorClass

--- a/Solver/src/libs/mpiutils/MPI_Face.f90
+++ b/Solver/src/libs/mpiutils/MPI_Face.f90
@@ -52,7 +52,9 @@ module MPI_Face_Class
 
    type MPI_FacesSet_t
       logical                          :: constructed = .false.
+	  integer                          :: nDomainShared
       type(MPI_Face_t), allocatable    :: faces(:)
+	  integer         , allocatable    :: listDomain(:)
    end type MPI_FacesSet_t
 
    interface MPI_Face_t
@@ -73,9 +75,14 @@ module MPI_Face_Class
 
          if ( MPI_Process % doMPIAction ) then
             allocate(facesSet % faces(MPI_Process % nProcs))
-
+			allocate(facesSet % listDomain(MPI_Process % nProcs))
+			
+			facesSet % nDomainShared = MPI_Process % nProcs
+			
             do domain = 1, MPI_Process % nProcs
                facesSet % faces(domain) = MPI_Face_t()
+			   facesSet % faces(domain) % no_of_faces = 0
+			   facesSet % listDomain (domain) = domain
             end do
          end if
 
@@ -101,7 +108,7 @@ module MPI_Face_Class
 !        ---------------
 !
          integer  :: domain
-
+		 
          do domain = 1, MPI_Process % nProcs
             facesSet % faces(domain) % nDOFs         = NDOFS(domain)
             facesSet % faces(domain) % sizeQ         = NCONS * NDOFS(domain)
@@ -109,6 +116,7 @@ module MPI_Face_Class
             facesSet % faces(domain) % sizeAviscFlux = NCONS * NDOFS(domain)
 
             if ( NDOFS(domain) .gt. 0 ) then
+			   
                safedeallocate(facesSet % faces(domain) % Qsend)
                safedeallocate(facesSet % faces(domain) % U_xyzsend)
                safedeallocate(facesSet % faces(domain) % Qrecv)
@@ -124,7 +132,6 @@ module MPI_Face_Class
                allocate( facesSet % faces(domain) % AviscFluxRecv(NCONS * NDOFS(domain)) )
             end if
          end do
-
       end subroutine ConstructMPIFacesStorage
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -132,177 +139,179 @@ module MPI_Face_Class
 !     ---------------------------------------
 !     Subroutine to send the polynomial order
 !     ---------------------------------------
-      subroutine MPI_Face_SendN(self, domain)
+      subroutine MPI_Face_SendN(self, domain, req)
          implicit none
          !-arguments-----------------------------------------------
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
+		 integer, intent(out)   :: req
          !-local-variables-----------------------------------------
-         integer  :: ierr, dummyreq
+         integer  :: ierr
          !---------------------------------------------------------
-
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
             call mpi_isend(self % Nsend, 6 * self % no_of_faces, MPI_INT, domain-1, DEFAULT_TAG, &
-                           MPI_COMM_WORLD, dummyreq, ierr)
-            call mpi_request_free(dummyreq, ierr)
+                           MPI_COMM_WORLD, req, ierr)
          end if
 #endif
-
       end subroutine MPI_Face_SendN
 !     ------------------------------------------
 !     Subroutine to receive the polynomial order
 !     ------------------------------------------
-      subroutine MPI_Face_RecvN(self, domain)
+      subroutine MPI_Face_RecvN(self, domain, req)
          implicit none
          !-arguments-----------------------------------------------
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
+		 integer, intent(out)   :: req
          !-local-variables-----------------------------------------
-         integer  :: ierr, dummyreq
+         integer  :: ierr
          !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
             call mpi_irecv(self % Nrecv, 6 * self % no_of_faces, MPI_INT, domain-1, MPI_ANY_TAG, &
-                           MPI_COMM_WORLD, self % Nrecv_req, ierr)
+                           MPI_COMM_WORLD, req, ierr)
+			self % Nrecv_req = req
          end if
 #endif
-
       end subroutine MPI_Face_RecvN
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
-      subroutine MPI_Face_SendQ(self, domain, nEqn)
+!     ---------------------------------
+!     Subroutine to send the variable Q
+!     ---------------------------------
+      subroutine MPI_Face_SendQ(self, domain, nEqn, req)
          implicit none
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
-         integer,    intent(in) :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_isend(self % Qsend, nEqn * self % nDOFs, MPI_DOUBLE, domain-1, DEFAULT_TAG, &
-                           MPI_COMM_WORLD, dummyreq, ierr)
-            call mpi_request_free(dummyreq, ierr)
+            call mpi_isend(self % Qsend, nEqn * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, DEFAULT_TAG, &
+                           MPI_COMM_WORLD, req, ierr)
          end if
 #endif
-
       end subroutine MPI_Face_SendQ
-
-      subroutine MPI_Face_RecvQ(self, domain, nEqn)
+!     ------------------------------------
+!     Subroutine to receive the variable Q
+!     ------------------------------------
+      subroutine MPI_Face_RecvQ(self, domain, nEqn, req)
          implicit none
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
-         integer,    intent(in) :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
+		 self % Qrecv_req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_irecv(self % Qrecv, nEqn * self % nDOFs, MPI_DOUBLE, domain-1, MPI_ANY_TAG, &
-                           MPI_COMM_WORLD, self % Qrecv_req, ierr)
+            call mpi_irecv(self % Qrecv, nEqn * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, MPI_ANY_TAG, &
+                           MPI_COMM_WORLD, req, ierr)
+			self % Qrecv_req = req
          end if
 #endif
-
       end subroutine MPI_Face_RecvQ
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
-      subroutine MPI_Face_SendU_xyz(self, domain, nEqn)
+!     -------------------------------------
+!     Subroutine to send the variable gradQ
+!     -------------------------------------
+      subroutine MPI_Face_SendU_xyz(self, domain, nEqn, req)
          implicit none
-         class(MPI_Face_t)    :: self
-         integer, intent(in)  :: domain
-         integer, intent(in)  :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         class(MPI_Face_t)      :: self
+         integer, intent(in)    :: domain
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_isend(self % U_xyzsend, nEqn * NDIM * self % nDOFs, MPI_DOUBLE, domain-1, &
-                           DEFAULT_TAG, MPI_COMM_WORLD, dummyreq, ierr)
-            call mpi_request_free(dummyreq, ierr)
+            call mpi_isend(self % U_xyzsend, nEqn * NDIM * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, &
+                           DEFAULT_TAG, MPI_COMM_WORLD, req, ierr)
          end if
 #endif
-
       end subroutine MPI_Face_SendU_xyz
-
-      subroutine MPI_Face_RecvU_xyz(self, domain, nEqn)
+!     ----------------------------------------
+!     Subroutine to receive the variable gradQ
+!     ----------------------------------------
+      subroutine MPI_Face_RecvU_xyz(self, domain, nEqn, req)
          implicit none
-         class(MPI_Face_t)    :: self
-         integer, intent(in)  :: domain
-         integer, intent(in)  :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         class(MPI_Face_t)      :: self
+         integer, intent(in)    :: domain
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
+		 self % gradQrecv_req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_irecv(self % U_xyzrecv, nEqn * NDIM * self % nDOFs, MPI_DOUBLE, domain-1, &
-                           DEFAULT_TAG, MPI_COMM_WORLD, self % gradQrecv_req, ierr)
+            call mpi_irecv(self % U_xyzrecv, nEqn * NDIM * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, &
+                           DEFAULT_TAG, MPI_COMM_WORLD, req, ierr)
+			self % gradQrecv_req = req
          end if
 #endif
-
       end subroutine MPI_Face_RecvU_xyz
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 !
-      subroutine MPI_Face_SendAviscFlux(self, domain, nEqn)
+!     --------------------------------
+!     Subroutine to send the AviscFlux
+!     --------------------------------
+      subroutine MPI_Face_SendAviscFlux(self, domain, nEqn, req)
          implicit none
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
-         integer,    intent(in) :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_isend(self % AviscFluxSend, nEqn * self % nDOFs, MPI_DOUBLE, domain-1, &
-                           DEFAULT_TAG, MPI_COMM_WORLD, dummyreq, ierr)
-            call mpi_request_free(dummyreq, ierr)
+            call mpi_isend(self % AviscFluxSend, nEqn * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, &
+                           DEFAULT_TAG, MPI_COMM_WORLD, req, ierr)
          end if
 #endif
 
       end subroutine MPI_Face_SendAviscFlux
-
-      subroutine MPI_Face_RecvAviscFlux(self, domain, nEqn)
+!     -----------------------------------
+!     Subroutine to receive the AviscFlux
+!     -----------------------------------
+      subroutine MPI_Face_RecvAviscFlux(self, domain, nEqn, req)
          implicit none
          class(MPI_Face_t)      :: self
          integer, intent(in)    :: domain
-         integer,    intent(in) :: nEqn
-!
-!        ---------------
-!        Local variables
-!        ---------------
-!
-         integer  :: ierr, dummyreq
-
+         integer, intent(in)    :: nEqn
+		 integer, intent(out)   :: req
+         !-local-variables-----------------------------------------
+         integer  :: ierr
+         !---------------------------------------------------------
 #ifdef _HAS_MPI_
+		 req = MPI_REQUEST_NULL
+		 self % AviscFluxRecv_req = MPI_REQUEST_NULL
          if ( self % no_of_faces .gt. 0 ) then
-            call mpi_irecv(self % AviscFluxRecv, nEqn * self % nDOFs, MPI_DOUBLE, domain-1, &
-                           MPI_ANY_TAG, MPI_COMM_WORLD, self % AviscFluxRecv_req, ierr)
+            call mpi_irecv(self % AviscFluxRecv, nEqn * self % nDOFs, MPI_DOUBLE_PRECISION, domain-1, &
+                           MPI_ANY_TAG, MPI_COMM_WORLD, req, ierr)
+			self % AviscFluxRecv_req = req
          end if
 #endif
-
       end subroutine MPI_Face_RecvAviscFlux
 !
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -408,12 +417,14 @@ module MPI_Face_Class
 !
          integer  :: domain
 
-         if ( MPI_Process % doMPIAction ) then
+         if ( MPI_Process % doMPIAction .and. (allocated(facesSet % faces))) then
             do domain = 1, MPI_Process % nProcs
                call facesSet % faces(domain) % Destruct()
             end do
             safedeallocate(facesSet % faces)
+			safedeallocate(facesSet % listDomain)
          end if
+		 facesSet % constructed = .FALSE.
 
       end subroutine DestructMPIFaces
 

--- a/Solver/src/libs/mpiutils/partitioned_mesh.f90
+++ b/Solver/src/libs/mpiutils/partitioned_mesh.f90
@@ -60,7 +60,9 @@ module PartitionedMeshClass
 !        -------------------------------------------------      
          if ( MPI_Process % doMPIRootAction ) then
 #ifdef _HAS_MPI_
-            allocate(mpi_allPartitions(MPI_Process % nProcs))
+            if (.not. allocated(mpi_allPartitions)) THEN
+				allocate(mpi_allPartitions(MPI_Process % nProcs))
+			end if 
 #endif
             do domain = 1, MPI_Process % nProcs
                mpi_allPartitions(domain) = PartitionedMesh_t(domain)

--- a/Solver/src/libs/timeintegrator/ExplicitMethods.f90
+++ b/Solver/src/libs/timeintegrator/ExplicitMethods.f90
@@ -1525,44 +1525,38 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
       REAL(KIND=RP), DIMENSION(3) :: a = (/0.0_RP       , -5.0_RP /9.0_RP , -153.0_RP/128.0_RP/)
       REAL(KIND=RP), DIMENSION(4) :: b = (/0.0_RP       ,  1.0_RP /3.0_RP ,    3.0_RP/4.0_RP  ,     1.0_RP     /)
       REAL(KIND=RP), DIMENSION(3) :: c = (/1.0_RP/3.0_RP,  15.0_RP/16.0_RP,    8.0_RP/15.0_RP /)
-	  REAL(KIND=RP), DIMENSION(3) :: d 
+	  REAL(KIND=RP), DIMENSION(3) :: d = (/1.0_RP/3.0_RP,  5.0_RP/12.0_RP,    1.0_RP/4.0_RP /)        ! Temporal step of stages
 	  
 
 
-     INTEGER       :: i, j, id, lID, locLevel, k2, k3, k1, nLevel
+      INTEGER       :: i, j, id, locLevel, k2, k3, k1, nLevel
 	  INTEGER, ALLOCATABLE :: k(:)
-	  REAL(KIND=RP) :: deltaStep(3), corrector, deltaTLF
-	  REAL(KIND=RP), ALLOCATABLE :: cL(:) , tk(:), deltaTL(:)
+	  INTEGER, parameter :: kmax = 3
+	  REAL(KIND=RP) :: corrector
+	  REAL(KIND=RP), ALLOCATABLE :: cL(:) , tk(:), deltaTL(:) ! 
 
-     logical :: updateQLowRK
+      logical :: updateQLowRK
 
-     if (present(dtAdaptation)) then
+      if (present(dtAdaptation)) then
          updateQLowRK = dtAdaptation
-     else
+      else
          updateQLowRK = .false.
-     end if
+      end if
 	  
 	  nLevel = mesh % MLRK % maxLevel
 	  allocate(k(nLevel), cL(nLevel), tk(nLevel), deltaTL(nLevel))
-	  k(:) = 1
 	  
-	  d(1)=1.0_RP/3.0_RP
-	  d(2)=5.0_RP/12.0_RP
-	  d(3)=1.0_RP/4.0_RP
-	 
-	  deltaStep(1) =  b(2)
-     deltaStep(2) =  b(3)-b(2)
-     deltaStep(3) =  1.0_RP-b(3)	
-	  
-	  deltaTL(:) = deltaT
+	  deltaTL(:) = deltaT		! Local timestep, for level 1 is the deltaT
 	  tk(:)      = t
 	  
 	  associate ( MLIter_eID => mesh % MLRK % MLIter_eID, MLIter => mesh % MLRK % MLIter  )
 	  
-      k(:) = 3
-      do k1 = 1,3
-         tk(:) = t + b(k1)*deltaT
-         call ComputeTimeDerivative( mesh, particles, tk(1), CTD_IGNORE_MODE)
+      k(:) = kmax                ! A counter array to track at which stage and level , 3 is the total number of stages
+      do k1 = 1,kmax
+!           LEVEL 1
+            tk(:) = t + b(k1)*deltaT    											! Actual time at each level 
+            call ComputeTimeDerivative( mesh, particles, tk(1), CTD_IGNORE_MODE)  	! Compute Qdot all elements
+			locLevel = 1															! Level locator
 
          if (k1==1 .and. updateQLowRK) then !For adaptive time step only, update QLowRK
 !$omp parallel do schedule(runtime)
@@ -1574,14 +1568,13 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
 !$omp end parallel do
          end if
 
-			locLevel = 1
 !           -------------------------------------------------------------------------------------------------------------------------------
 !           LEVEL 2-LEVEL N-1
 !           -------------------------------------------------------------------------------------------------------------------------------
-			do k2 = 1, max(3**(nLevel-2),1)
-				k(nLevel-1) = k(nLevel-1)+1
-				do i=nLevel-1,1,-1
-					if (k(i).gt.3) then
+			do k2 = 1, max(kmax**(nLevel-2),1)				! loop for the intermediate levels nstages**(nLevel-2)
+				k(nLevel-1) = k(nLevel-1)+1					! Update the counter level-stages by adding by 1 for nLevel-1
+				do i=nLevel-1,1,-1							! Check if stages already exceed total number of stages
+					if (k(i).gt.kmax) then
 						k(i)=1
 						if (i.ne.1) then
 							k(i-1)=k(i-1) +1
@@ -1591,23 +1584,23 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
 					end if						
 				end do 
 				
-				do i=2, nLevel
-					deltaTL(i) = deltaTL(i-1) * deltaStep(k(i-1))
+				do i=2, nLevel 								! Update the local timestep for level 2: nLevel
+					deltaTL(i) = deltaTL(i-1) * d(k(i-1))
 				end do 
 !               -------------------------------------------------------------------------------------------------------------------------------
 !               LEVEL N 
 !               -------------------------------------------------------------------------------------------------------------------------------
-				do k3 = 1,3
-					k(nLevel) = k3
+				do k3 = 1,kmax
+					k(nLevel) = k3							! Update the counter level-stages for nLevel 
 !           		Update G_NS/G_CH from QDot - Depend on level etc
 !$omp parallel do schedule(runtime)	private(id, corrector)	
-					do i = 1, MLIter(locLevel,1)
-						id = MLIter_eID(i)
-						
-						if (locLevel.eq.nLevel) then
-							corrector = a(k(nLevel))
+					do i = 1, MLIter(locLevel,1)            ! Loop all elements at the active level to update the G / Qdot contribution
+						id = MLIter_eID(i)					! ID of true element at partition
+	  
+						if (locLevel.eq.nLevel) then		! Variable a, weight of the previous Qdot contribution
+							corrector = a(k(nLevel))		
 					    elseif(i.gt.MLIter(min(locLevel+1,nLevel),1)) then 
-							corrector = a(k(locLevel))
+							corrector = a(k(locLevel))		! If locLevel is j then all element with level > j will be on first stage corrector=0
 						else
 							corrector = 0.0_RP
 						end if 
@@ -1629,7 +1622,7 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
 						corrector = corrector * d(k(i))
 					end do 
                     do i = 1, nLevel
-						cL(i) = c(k(i)) * corrector/d(k(i)) 
+						cL(i) = c(k(i)) * corrector/d(k(i)) ! Timestep scaling for local timesteping at level N for all level 
 					end do 
 
 !$omp parallel do schedule(runtime)	private(id, corrector)			
@@ -1652,19 +1645,17 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
 						end associate
 					end do
 !$omp end parallel do	
-                    if (all(k(2:nLevel) == 3)) then
+                    if (all(k(2:nLevel) == kmax)) then
 						exit
 					else
 						do i=nLevel,2,-1
-						    locLevel =i
-							if (k(i).ne.3) exit
+						    locLevel =i                   	! The level for next loop
+							if (k(i).ne.kmax) exit
 						end do 
 					end if 
 					
 					tk(locLevel)=tk(locLevel-1)+b(k(locLevel)+1) * deltaTL(locLevel)
-					
-					call ComputeTimeDerivative( mesh, particles, tk(locLevel), CTD_IGNORE_MODE, Level = locLevel) ! Update Qdot
-					
+					call ComputeTimeDerivative( mesh, particles, tk(locLevel), CTD_IGNORE_MODE, Level=locLevel) ! Update Qdot
 				end do 
 			end do 
 
@@ -1672,12 +1663,14 @@ SUBROUTINE TakeMixedRKStep( mesh, particles, t, deltaT, ComputeTimeDerivative , 
 	   
 	   end associate
 	   
-	   call ComputeTimeDerivative( mesh, particles, t+deltaT, CTD_IGNORE_MODE, Level = 1) ! Necessary for residual computation
+	   call ComputeTimeDerivative( mesh, particles, t+deltaT, CTD_IGNORE_MODE) ! Necessary for residual computation
 !
 !     To obtain the updated residuals
       if ( CTD_AFTER_STEPS ) CALL ComputeTimeDerivative( mesh, particles, t+deltaT, CTD_IGNORE_MODE)
 
       call checkForNan(mesh, t)
+	  
+	  deallocate(k, cL, tk, deltaTL)
 
    END SUBROUTINE TakeMLRK3Step
 !

--- a/Solver/src/libs/timeintegrator/TimeIntegrator.f90
+++ b/Solver/src/libs/timeintegrator/TimeIntegrator.f90
@@ -894,7 +894,7 @@
 !        --------------
          IF( self % pAdaptator % hasToAdapt(k+1) .or. dtHasToAdapt ) then
             call self % pAdaptator % pAdapt(sem,k,t, ComputeTimeDerivative, ComputeTimeDerivativeIsolated, controlVariables, self % adaptiveTimeStep)
-			   call samplings % UpdateInterp(sem % mesh)
+			call samplings % UpdateInterp(sem % mesh)
          end if
          call self % TauEstimator % estimate(sem, k+1, t, ComputeTimeDerivative, ComputeTimeDerivativeIsolated)
 !

--- a/Solver/src/libs/timeintegrator/pAdaptationClass.f90
+++ b/Solver/src/libs/timeintegrator/pAdaptationClass.f90
@@ -64,7 +64,7 @@ module pAdaptationClass
       real(kind=RP)     :: y_span(2)
       real(kind=RP)     :: z_span(2)
       integer           :: mode
-	   integer           :: polynomial(3)
+	  integer           :: polynomial(3)
       integer           :: region
       
       contains
@@ -104,7 +104,7 @@ module pAdaptationClass
       real(kind=RP)                     :: nextAdaptationTime = huge(1._RP)
       character(len=BC_STRING_LENGTH), allocatable :: conformingBoundaries(:) ! Stores the conforming boundaries (the length depends on FTDictionaryClass)
       type(overenriching_t)  , allocatable :: overenriching(:)
-	   type(pAdaptVariable_t) , allocatable :: adaptVariable(:)
+	  type(pAdaptVariable_t) , allocatable :: adaptVariable(:)
       
       contains
          procedure(constructInterface), deferred :: pAdaptation_Construct
@@ -796,6 +796,8 @@ readloop:do
 	  end do 
 !$omp end do
 !$omp end parallel
+	  
+	  deallocate(neighborIDAll)
    
    end subroutine pAdapt_CheckNeighbour
 !

--- a/Solver/test/NavierStokes/Cylinder_MLRK/Cylinder_MLRK.control
+++ b/Solver/test/NavierStokes/Cylinder_MLRK/Cylinder_MLRK.control
@@ -1,0 +1,74 @@
+Flow equations        = "NS"
+mesh file name        = "../../TestMeshes/CylinderNSpol3.mesh"
+Polynomial order      = 3
+Number of time steps  = 20
+Output Interval       = 10
+Number of plot points = 5
+Convergence tolerance = 1.d-10
+mach number           = 0.3
+Reynolds number       = 200.0
+interface width (dimensionless) = 2.0
+peclet number = 0.005
+AOA theta             = 0.0
+AOA phi               = 90.0
+solution file name    = "RESULTS/Cylinder.hsol"
+save gradients with solution = .true.
+restart               = .false.
+restart file name     = "RESULTS/Cylinder.hsol"
+riemann solver        = roe
+
+simulation type       = time-accurate
+explicit method       = multi level rk3
+optimized partition   = .true.                 ! Sometimes .false. is better 
+dt                    = 0.008			
+relevel iteration     = 1000000000000
+number of level       = 2
+cfl cut-off           = 0.5
+monitor memory        = .true.
+
+
+#define boundary InnerCylinder
+  type = NoSlipWall
+#end
+
+#define boundary bottom__top
+  type = FreeSlipWall
+#end
+
+#define boundary back__left__front
+  type = Inflow
+#end
+
+#define boundary right
+  type = Outflow
+#end
+
+#define surface monitor 1
+   Name = cyl-drag
+   Marker = innercylinder
+   Variable = drag
+   Direction = [0.0,0.0,1.0]
+   Reference surface = 1.0	
+#end
+
+#define surface monitor 2
+   Name = cyl-lift
+   Marker = innercylinder
+   Variable = lift
+   Direction = [1.0,0.0,0.0]
+   Reference surface = 1.0
+#end
+
+#define probe 1
+   Name = wake_u
+   Position = [0.0,2.0,4.0]
+   Variable = u
+#end
+
+!#define statistics
+!   Sampling interval = 10
+!   Starting iteration = 15
+!   Starting time = 0.0
+!   @start*
+!   @stop
+!#end

--- a/Solver/test/NavierStokes/Cylinder_MLRK/SETUP/ProblemFile.f90
+++ b/Solver/test/NavierStokes/Cylinder_MLRK/SETUP/ProblemFile.f90
@@ -1,0 +1,643 @@
+!
+!////////////////////////////////////////////////////////////////////////
+!
+!      The Problem File contains user defined procedures
+!      that are used to "personalize" i.e. define a specific
+!      problem to be solved. These procedures include initial conditions,
+!      exact solutions (e.g. for tests), etc. and allow modifications 
+!      without having to modify the main code.
+!
+!      The procedures, *even if empty* that must be defined are
+!
+!      UserDefinedSetUp
+!      UserDefinedInitialCondition(mesh)
+!      UserDefinedPeriodicOperation(mesh)
+!      UserDefinedFinalize(mesh)
+!      UserDefinedTermination
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#include "Includes.h"
+module ProblemFileFunctions
+   implicit none
+
+   abstract interface
+      subroutine UserDefinedStartup_f
+      end subroutine UserDefinedStartup_f
+   
+      SUBROUTINE UserDefinedFinalSetup_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         USE HexMeshClass
+         use FluidData
+         IMPLICIT NONE
+         CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      END SUBROUTINE UserDefinedFinalSetup_f
+
+      subroutine UserDefinedInitialCondition_f(mesh &
+#ifdef FLOW
+                                     , thermodynamics_ &
+                                     , dimensionless_  &
+                                     , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                     , multiphase_ &
+#endif
+                                     )
+         use smconstants
+         use physicsstorage
+         use hexmeshclass
+         use fluiddata
+         implicit none
+         class(hexmesh)                      :: mesh
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedInitialCondition_f
+#ifdef FLOW
+      subroutine UserDefinedState_f(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP)  :: x(NDIM)
+         real(kind=RP)  :: t
+         real(kind=RP)  :: nHat(NDIM)
+         real(kind=RP)  :: Q(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+      end subroutine UserDefinedState_f
+
+      subroutine UserDefinedGradVars_f(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)          :: x(NDIM)
+         real(kind=RP), intent(in)          :: t
+         real(kind=RP), intent(in)          :: nHat(NDIM)
+         real(kind=RP), intent(in)          :: Q(NCONS)
+         real(kind=RP), intent(inout)       :: U(NGRAD)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedGradVars_f
+
+
+      subroutine UserDefinedNeumann_f(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+         use SMConstants
+         use PhysicsStorage
+         use FluidData
+         implicit none
+         real(kind=RP), intent(in)    :: x(NDIM)
+         real(kind=RP), intent(in)    :: t
+         real(kind=RP), intent(in)    :: nHat(NDIM)
+         real(kind=RP), intent(in)    :: Q(NCONS)
+         real(kind=RP), intent(in)    :: U_x(NGRAD)
+         real(kind=RP), intent(in)    :: U_y(NGRAD)
+         real(kind=RP), intent(in)    :: U_z(NGRAD)
+         real(kind=RP), intent(inout) :: flux(NCONS)
+         type(Thermodynamics_t), intent(in) :: thermodynamics_
+         type(Dimensionless_t),  intent(in) :: dimensionless_
+         type(RefValues_t),      intent(in) :: refValues_
+      end subroutine UserDefinedNeumann_f
+
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedPeriodicOperation_f(mesh, time, dt, Monitors)
+         use SMConstants
+         USE HexMeshClass
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)               :: mesh
+         REAL(KIND=RP)                :: time
+         REAL(KIND=RP)                :: dt
+         type(Monitor_t), intent(in) :: monitors
+      END SUBROUTINE UserDefinedPeriodicOperation_f
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+      subroutine UserDefinedSourceTermNS_f(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+,multiphase_ &
+#endif
+)
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use PhysicsStorage
+         IMPLICIT NONE
+         real(kind=RP),             intent(in)  :: x(NDIM)
+         real(kind=RP),             intent(in)  :: Q(NCONS)
+         real(kind=RP),             intent(in)  :: time
+         real(kind=RP),             intent(inout) :: S(NCONS)
+         type(Thermodynamics_t), intent(in)  :: thermodynamics_
+         type(Dimensionless_t),  intent(in)  :: dimensionless_
+         type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+      end subroutine UserDefinedSourceTermNS_f
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedFinalize_f(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                 , thermodynamics_ &
+                                                 , dimensionless_  &
+                                                 , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                 , multiphase_ &
+#endif
+                                                 , monitors, &
+                                                   elapsedTime, &
+                                                   CPUTime   )
+         use SMConstants
+         USE HexMeshClass
+         use FluidData
+         use MonitorsClass
+         IMPLICIT NONE
+         CLASS(HexMesh)                        :: mesh
+         REAL(KIND=RP)                         :: time
+         integer                               :: iter
+         real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+         type(Thermodynamics_t), intent(in)    :: thermodynamics_
+         type(Dimensionless_t),  intent(in)    :: dimensionless_
+         type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+         type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+         type(Monitor_t),        intent(in)    :: monitors
+         real(kind=RP),             intent(in) :: elapsedTime
+         real(kind=RP),             intent(in) :: CPUTime
+      END SUBROUTINE UserDefinedFinalize_f
+
+      SUBROUTINE UserDefinedTermination_f
+         implicit none
+      END SUBROUTINE UserDefinedTermination_f
+   end interface
+   
+end module ProblemFileFunctions
+
+         SUBROUTINE UserDefinedStartup
+!
+!        --------------------------------
+!        Called before any other routines
+!        --------------------------------
+!
+            IMPLICIT NONE  
+         END SUBROUTINE UserDefinedStartup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalSetup(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ----------------------------------------------------------------------
+!           Called after the mesh is read in to allow mesh related initializations
+!           or memory allocations.
+!           ----------------------------------------------------------------------
+!
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            CLASS(HexMesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+         END SUBROUTINE UserDefinedFinalSetup
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         subroutine UserDefinedInitialCondition(mesh &
+#ifdef FLOW
+                                        , thermodynamics_ &
+                                        , dimensionless_  &
+                                        , refValues_ & 
+#endif
+#ifdef CAHNHILLIARD
+                                        , multiphase_ &
+#endif
+                                        )
+!
+!           ------------------------------------------------
+!           called to set the initial condition for the flow
+!              - by default it sets an uniform initial
+!                 condition.
+!           ------------------------------------------------
+!
+            use smconstants
+            use physicsstorage
+            use hexmeshclass
+            use fluiddata
+            implicit none
+            class(hexmesh)                      :: mesh
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           local variables
+!           ---------------
+!
+            integer        :: eid, i, j, k
+            real(kind=RP)  :: qq, u, v, w, p
+#if defined(NAVIERSTOKES)
+            real(kind=RP)  :: Q(NCONS), phi, theta
+#endif
+
+!
+!           ---------------------------------------
+!           Navier-Stokes default initial condition
+!           ---------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            associate ( gammaM2 => dimensionless_ % gammaM2, &
+                        gamma => thermodynamics_ % gamma )
+            theta = refvalues_ % AOAtheta*(pi/180.0_RP)
+            phi   = refvalues_ % AOAphi*(pi/180.0_RP)
+      
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  qq = 1.0_RP
+                  u  = qq*cos(theta)*cos(phi)
+                  v  = qq*sin(theta)*cos(phi)
+                  w  = qq*sin(phi)
+      
+                  q(1) = 1.0_RP
+                  p    = 1.0_RP/(gammaM2)
+                  q(2) = q(1)*u
+                  q(3) = q(1)*v
+                  q(4) = q(1)*w
+                  q(5) = p/(gamma - 1._RP) + 0.5_RP*q(1)*(u**2 + v**2 + w**2)
+
+                  mesh % elements(eID) % storage % q(:,i,j,k) = q 
+               end do;        end do;        end do
+               end associate
+            end do
+
+            end associate
+#endif
+!
+!           ------------------------------------------------------
+!           Incompressible Navier-Stokes default initial condition
+!           ------------------------------------------------------
+!
+#if defined(INCNS)
+            do eID = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eID) % Nxyz(1), &
+                          ny => mesh % elemeNts(eID) % nxyz(2), &
+                          Nz => mesh % elements(eID) % Nxyz(3) )
+               do k = 0, Nz;  do j = 0, Ny;  do i = 0, Nx 
+                  mesh % elements(eID) % storage % q(:,i,j,k) = [1.0_RP, 1.0_RP,0.0_RP,0.0_RP,0.0_RP] 
+               end do;        end do;        end do
+               end associate
+            end do
+#endif
+
+!
+!           ---------------------------------------
+!           Cahn-Hilliard default initial condition
+!           ---------------------------------------
+!
+#ifdef CAHNHILLIARD
+            call random_seed()
+         
+            do eid = 1, mesh % no_of_elements
+               associate( Nx => mesh % elements(eid) % Nxyz(1), &
+                          Ny => mesh % elements(eid) % Nxyz(2), &
+                          Nz => mesh % elements(eid) % Nxyz(3) )
+               associate(e => mesh % elements(eID) % storage)
+               call random_number(e % c) 
+               e % c = 2.0_RP * (e % c - 0.5_RP)
+               end associate
+               end associate
+            end do
+#endif
+
+         end subroutine UserDefinedInitialCondition
+#ifdef FLOW
+         subroutine UserDefinedState1(x, t, nHat, Q, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)     :: x(NDIM)
+            real(kind=RP), intent(in)     :: t
+            real(kind=RP), intent(in)     :: nHat(NDIM)
+            real(kind=RP), intent(inout)  :: Q(NCONS)
+            type(Thermodynamics_t),    intent(in)  :: thermodynamics_
+            type(Dimensionless_t),     intent(in)  :: dimensionless_
+            type(RefValues_t),         intent(in)  :: refValues_
+         end subroutine UserDefinedState1
+
+         subroutine UserDefinedGradVars1(x, t, nHat, Q, U, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)          :: x(NDIM)
+            real(kind=RP), intent(in)          :: t
+            real(kind=RP), intent(in)          :: nHat(NDIM)
+            real(kind=RP), intent(in)          :: Q(NCONS)
+            real(kind=RP), intent(inout)       :: U(NGRAD)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedGradVars1
+
+         subroutine UserDefinedNeumann1(x, t, nHat, Q, U_x, U_y, U_z, flux, thermodynamics_, dimensionless_, refValues_)
+            use SMConstants
+            use PhysicsStorage
+            use FluidData
+            implicit none
+            real(kind=RP), intent(in)    :: x(NDIM)
+            real(kind=RP), intent(in)    :: t
+            real(kind=RP), intent(in)    :: nHat(NDIM)
+            real(kind=RP), intent(in)    :: Q(NCONS)
+            real(kind=RP), intent(in)    :: U_x(NGRAD)
+            real(kind=RP), intent(in)    :: U_y(NGRAD)
+            real(kind=RP), intent(in)    :: U_z(NGRAD)
+            real(kind=RP), intent(inout) :: flux(NCONS)
+            type(Thermodynamics_t), intent(in) :: thermodynamics_
+            type(Dimensionless_t),  intent(in) :: dimensionless_
+            type(RefValues_t),      intent(in) :: refValues_
+         end subroutine UserDefinedNeumann1
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedPeriodicOperation(mesh, time, dt, Monitors)
+!
+!           ----------------------------------------------------------
+!           Called before every time-step to allow periodic operations
+!           to be performed
+!           ----------------------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)               :: mesh
+            REAL(KIND=RP)                :: time
+            REAL(KIND=RP)                :: dt
+            type(Monitor_t), intent(in) :: monitors
+            
+         END SUBROUTINE UserDefinedPeriodicOperation
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+#ifdef FLOW
+         subroutine UserDefinedSourceTermNS(x, Q, time, S, thermodynamics_, dimensionless_, refValues_ &
+#ifdef CAHNHILLIARD
+, multiphase_ &
+#endif
+)
+!
+!           --------------------------------------------
+!           Called to apply source terms to the equation
+!           --------------------------------------------
+!
+            use SMConstants
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            IMPLICIT NONE
+            real(kind=RP),             intent(in)  :: x(NDIM)
+            real(kind=RP),             intent(in)  :: Q(NCONS)
+            real(kind=RP),             intent(in)  :: time
+            real(kind=RP),             intent(inout) :: S(NCONS)
+            type(Thermodynamics_t), intent(in)  :: thermodynamics_
+            type(Dimensionless_t),  intent(in)  :: dimensionless_
+            type(RefValues_t),      intent(in)  :: refValues_
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)  :: multiphase_
+#endif
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            integer  :: i, j, k, eID
+!
+!           Usage example
+!           -------------
+!           S(:) = x(1) + x(2) + x(3) + time
+   
+         end subroutine UserDefinedSourceTermNS
+#endif
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+         SUBROUTINE UserDefinedFinalize(mesh, time, iter, maxResidual &
+#ifdef FLOW
+                                                    , thermodynamics_ &
+                                                    , dimensionless_  &
+                                                    , refValues_ & 
+#endif   
+#ifdef CAHNHILLIARD
+                                                    , multiphase_ &
+#endif
+                                                    , monitors, &
+                                                      elapsedTime, &
+                                                      CPUTime   )
+!
+!           --------------------------------------------------------
+!           Called after the solution computed to allow, for example
+!           error tests to be performed
+!           --------------------------------------------------------
+!
+            use SMConstants
+            use FTAssertions
+            USE HexMeshClass
+            use PhysicsStorage
+            use FluidData
+            use MonitorsClass
+            IMPLICIT NONE
+            CLASS(HexMesh)                        :: mesh
+            REAL(KIND=RP)                         :: time
+            integer                               :: iter
+            real(kind=RP)                         :: maxResidual
+#ifdef FLOW
+            type(Thermodynamics_t), intent(in)    :: thermodynamics_
+            type(Dimensionless_t),  intent(in)    :: dimensionless_
+            type(RefValues_t),      intent(in)    :: refValues_
+#endif
+#ifdef CAHNHILLIARD
+            type(Multiphase_t),     intent(in)    :: multiphase_
+#endif
+            type(Monitor_t),        intent(in)    :: monitors
+            real(kind=RP),             intent(in) :: elapsedTime
+            real(kind=RP),             intent(in) :: CPUTime
+!
+!           ---------------
+!           Local variables
+!           ---------------
+!
+            CHARACTER(LEN=29)                  :: testName           = "Re 200 Cylinder"
+            REAL(KIND=RP)                      :: maxError
+            REAL(KIND=RP), ALLOCATABLE         :: QExpected(:,:,:,:)
+            INTEGER                            :: eID
+            INTEGER                            :: i, j, k, N
+            TYPE(FTAssertionsManager), POINTER :: sharedManager
+            LOGICAL                            :: success
+!
+!           -----------------------------------------------------------------------------------------
+!           Expected solutions. 
+!           InnerCylinder 0.0 NoSlipAdiabaticWall
+!           Front 0.0 Inflow
+!           bottom 0.0 FreeSlipWall
+!           top 0.0 FreeSlipWall
+!           Back 0.0 Inflow
+!           Left 0.0 Inflow
+!           Right 0.0 OutflowSpecifyP 
+!           -----------------------------------------------------------------------------------------
+!
+!
+!           ------------------------------------------------
+!           Expected Solutions: Wall conditions on the sides
+!           Number of iterations are for CFL of 0.3, for
+!           the roe solver and mach = 0.3
+!           ------------------------------------------------
+!
+#if defined(NAVIERSTOKES)
+            INTEGER                            :: iterations(3:7) = [20, 0, 0, 0, 0]
+  
+            real(kind=RP), parameter :: residuals(5) = [ 6.4366298273677529E+00_RP, &
+                                                         1.4382326132608259E+01_RP, &
+                                                         6.75679612029929E-02_RP, &
+                                                         1.6613872737245508E+01_RP, &
+                                                         1.7523096637012696E+02_RP]
+
+            real(kind=RP), parameter           :: wake_u = 1.0965307794823676E-08_RP
+            real(kind=RP), parameter           :: cd = 2.7645531468829969E+01_RP
+            real(kind=RP), parameter           :: cl = -7.9050985992168E-04_RP
+
+!
+            N = mesh % elements(1) % Nxyz(1) ! This works here because all the elements have the same order in all directions
+
+            CALL initializeSharedAssertionsManager
+            sharedManager => sharedAssertionsManager()
+
+            CALL FTAssertEqual(expectedValue = residuals(1)+1.0_RP, &
+                               actualValue   = monitors % residuals % values(1,1)+1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Continuity residual")
+
+            CALL FTAssertEqual(expectedValue = residuals(2)+1.0_RP, &
+                               actualValue   = monitors % residuals % values(2,1)+1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "X-Momentum residual")
+
+            CALL FTAssertEqual(expectedValue = residuals(3)+1.0_RP, &
+                               actualValue   = monitors % residuals % values(3,1)+1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Y-Momentum residual")
+
+            CALL FTAssertEqual(expectedValue = residuals(4)+1.0_RP, &
+                               actualValue   = monitors % residuals % values(4,1)+1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Z-Momentum residual")
+
+            CALL FTAssertEqual(expectedValue = residuals(5)+1.0_RP, &
+                               actualValue   = monitors % residuals % values(5,1)+1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Energy residual")
+
+            CALL FTAssertEqual(expectedValue = iterations(N), &
+                               actualValue   = iter, &
+                               msg           = "Number of time steps to tolerance")
+
+            CALL FTAssertEqual(expectedValue = cd, &
+                               actualValue   = monitors % surfaceMonitors(1) % values(1), &
+                               tol           = 1.d-11, &
+                               msg           = "Drag coefficient")
+
+            CALL FTAssertEqual(expectedValue = cl + 1.0_RP, &
+                               actualValue   = monitors % surfaceMonitors(2) % values(1) + 1.0_RP, &
+                               tol           = 1.d-11, &
+                               msg           = "Lift coefficient")
+
+
+            CALL sharedManager % summarizeAssertions(title = testName,iUnit = 6)
+   
+            IF ( sharedManager % numberOfAssertionFailures() == 0 )     THEN
+               WRITE(6,*) testName, " ... Passed"
+               WRITE(6,*) "This test case has no expected solution yet, only checks the residual after 100 iterations."
+            ELSE
+               WRITE(6,*) testName, " ... Failed"
+               WRITE(6,*) "NOTE: Failure is expected when the max eigenvalue procedure is changed."
+               WRITE(6,*) "      If that is done, re-compute the expected values and modify this procedure"
+                error stop 99
+            END IF 
+            WRITE(6,*)
+            
+            CALL finalizeSharedAssertionsManager
+            CALL detachSharedAssertionsManager
+#endif
+
+
+         END SUBROUTINE UserDefinedFinalize
+!
+!//////////////////////////////////////////////////////////////////////// 
+! 
+      SUBROUTINE UserDefinedTermination
+!
+!        -----------------------------------------------
+!        Called at the the end of the main driver after 
+!        everything else is done.
+!        -----------------------------------------------
+!
+         IMPLICIT NONE  
+      END SUBROUTINE UserDefinedTermination
+      


### PR DESCRIPTION
This pull request modify the MPI face process to send and recv data of MPIfaces. The modification is to prevent memory leaking and communication mismatch in the solver. Mainly tested for multiphase for long run. A new monitor is added to monitor the total memory (see Cylinder_MLRK test). 
A new test case, Cylinder_MLRK is added in the NavierStokes test case to check MLRK time scheme.

This is a pending pull request from August