### PR TITLE
Memory leak fix

### DIFF
--- a/Solver/src/libs/mesh/HexMesh.f90
+++ b/Solver/src/libs/mesh/HexMesh.f90
@@ -2968,7 +2968,6 @@ slavecoord:             DO l = 1, 4
             case(HMESH_INTERIOR, HMESH_BOUNDARY)
                associate(eL => self % elements(f % elementIDs(1)))
                call f % geom % construct(f % Nf, f % NelLeft, f % NfLeft, eL % Nxyz, &
-                                         NodalStorage(f % Nf), NodalStorage(eL % Nxyz), &
                                          eL % geom, eL % hexMap, f % elementSide(1), &
                                          f % projectionType(1), 1, 0 )
                end associate
@@ -2991,7 +2990,6 @@ slavecoord:             DO l = 1, 4
 
                associate(e => self % elements(f % elementIDs(side)))
                call f % geom % construct(f % Nf, Nelf, Nel, e % Nxyz, &
-                                         NodalStorage(f % Nf), NodalStorage(e % Nxyz), &
                                          e % geom, e % hexMap, f % elementSide(side), &
                                          f % projectionType(side), side, rot)
 

--- a/Solver/src/libs/mesh/MappedGeometry.f90
+++ b/Solver/src/libs/mesh/MappedGeometry.f90
@@ -479,7 +479,7 @@ Module MappedGeometryClass
 !  -----------------------------------------
 !  Computation of the metric terms on a face
 !  -----------------------------------------
-   subroutine ConstructMappedGeometryFace(self, Nf, Nelf, Nel, Nel3D, spAf, spAe, geom, hexMap, side, projType, eSide, rot)
+   subroutine ConstructMappedGeometryFace(self, Nf, Nelf, Nel, Nel3D, geom, hexMap, side, projType, eSide, rot)
       use PhysicsStorage
       use InterpolationMatrices
       implicit none
@@ -488,8 +488,6 @@ Module MappedGeometryClass
       integer,                   intent(in)     :: Nelf(2)  ! Element face pOrder (with rotation)
       integer,                   intent(in)     :: Nel(2)   ! Element face pOrder (without rotation)
       integer,                   intent(in)     :: Nel3D(3) ! Element pOrder
-      type(NodalStorage_t),      intent(in)     :: spAf(2)
-      type(NodalStorage_t),      intent(in)     :: spAe(3)
       type(MappedGeometry),      intent(in)     :: geom
       type(TransfiniteHexMap),   intent(in)     :: hexMap
       integer,                   intent(in)     :: side
@@ -533,7 +531,7 @@ Module MappedGeometryClass
 !           Get face coordinates
 !           --------------------
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [-1.0_RP, xi, eta]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -541,10 +539,10 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,j,k) = dS(:,j,k) + geom % jGradXi(:,i,j,k) * spAe(1) % v(i,LEFT)
-               GradXi  (:,j,k) = GradXi  (:,j,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,LEFT)
-               GradEta (:,j,k) = GradEta (:,j,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,LEFT)
-               GradZeta(:,j,k) = GradZeta(:,j,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,LEFT)
+               dS(:,j,k) = dS(:,j,k) + geom % jGradXi(:,i,j,k) * NodalStorage(Nel3D(1)) % v(i,LEFT)
+               GradXi  (:,j,k) = GradXi  (:,j,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,LEFT)
+               GradEta (:,j,k) = GradEta (:,j,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,LEFT)
+               GradZeta(:,j,k) = GradZeta(:,j,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,LEFT)
             end do           ; end do           ; end do
 !
 !           Swap orientation
@@ -556,7 +554,7 @@ Module MappedGeometryClass
 !           Get face coordinates
 !           --------------------
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [ 1.0_RP, xi, eta ]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -564,15 +562,15 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,j,k) = dS(:,j,k) + geom % jGradXi(:,i,j,k) * spAe(1) % v(i,RIGHT)
-               GradXi  (:,j,k) = GradXi  (:,j,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,RIGHT)
-               GradEta (:,j,k) = GradEta (:,j,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,RIGHT)
-               GradZeta(:,j,k) = GradZeta(:,j,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(1) % v(i,RIGHT)
+               dS(:,j,k) = dS(:,j,k) + geom % jGradXi(:,i,j,k) * NodalStorage(Nel3D(1)) % v(i,RIGHT)
+               GradXi  (:,j,k) = GradXi  (:,j,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,RIGHT)
+               GradEta (:,j,k) = GradEta (:,j,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,RIGHT)
+               GradZeta(:,j,k) = GradZeta(:,j,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(1)) % v(i,RIGHT)
             end do           ; end do           ; end do
 
          case(EBOTTOM)
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [xi, eta,-1.0_RP]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -580,10 +578,10 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,i,j) = dS(:,i,j) + geom % jGradZeta(:,i,j,k) * spAe(3) % v(k,BOTTOM)
-               GradXi  (:,i,j) = GradXi  (:,i,j) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,BOTTOM)
-               GradEta (:,i,j) = GradEta (:,i,j) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,BOTTOM)
-               GradZeta(:,i,j) = GradZeta(:,i,j) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,BOTTOM)
+               dS(:,i,j) = dS(:,i,j) + geom % jGradZeta(:,i,j,k) * NodalStorage(Nel3D(3)) % v(k,BOTTOM)
+               GradXi  (:,i,j) = GradXi  (:,i,j) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,BOTTOM)
+               GradEta (:,i,j) = GradEta (:,i,j) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,BOTTOM)
+               GradZeta(:,i,j) = GradZeta(:,i,j) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,BOTTOM)
             end do           ; end do           ; end do
 !
 !           Swap orientation
@@ -592,7 +590,7 @@ Module MappedGeometryClass
 
          case(ETOP)
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [xi, eta, 1.0_RP]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -600,15 +598,15 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,i,j) = dS(:,i,j) + geom % jGradZeta(:,i,j,k) * spAe(3) % v(k,TOP)
-               GradXi  (:,i,j) = GradXi  (:,i,j) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,TOP)
-               GradEta (:,i,j) = GradEta (:,i,j) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,TOP)
-               GradZeta(:,i,j) = GradZeta(:,i,j) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(3) % v(k,TOP)
+               dS(:,i,j) = dS(:,i,j) + geom % jGradZeta(:,i,j,k) * NodalStorage(Nel3D(3)) % v(k,TOP)
+               GradXi  (:,i,j) = GradXi  (:,i,j) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,TOP)
+               GradEta (:,i,j) = GradEta (:,i,j) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,TOP)
+               GradZeta(:,i,j) = GradZeta(:,i,j) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(3)) % v(k,TOP)
             end do           ; end do           ; end do
 
          case(EFRONT)
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [xi, -1.0_RP, eta]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -616,10 +614,10 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,i,k) = dS(:,i,k) + geom % jGradEta(:,i,j,k) * spAe(2) % v(j,FRONT)
-               GradXi  (:,i,k) = GradXi  (:,i,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,FRONT)
-               GradEta (:,i,k) = GradEta (:,i,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,FRONT)
-               GradZeta(:,i,k) = GradZeta(:,i,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,FRONT)
+               dS(:,i,k) = dS(:,i,k) + geom % jGradEta(:,i,j,k) * NodalStorage(Nel3D(2)) % v(j,FRONT)
+               GradXi  (:,i,k) = GradXi  (:,i,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,FRONT)
+               GradEta (:,i,k) = GradEta (:,i,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,FRONT)
+               GradZeta(:,i,k) = GradZeta(:,i,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,FRONT)
             end do           ; end do           ; end do
 !
 !           Swap orientation
@@ -628,7 +626,7 @@ Module MappedGeometryClass
 
          case(EBACK)
             do j = 0, Nf(2) ; do i = 0, Nf(1)
-               call coordRotation(spAf(1) % x(i), spAf(2) % x(j), rot, xi, eta)
+               call coordRotation(NodalStorage(Nf(1)) % x(i), NodalStorage(Nf(2)) % x(j), rot, xi, eta)
                x = [xi, 1.0_RP, eta]
                self % x(:,i,j) = hexMap % transfiniteMapAt(x)
             end do ; end do
@@ -636,10 +634,10 @@ Module MappedGeometryClass
 !           Get surface Jacobian and normal vector
 !           --------------------------------------
             do k = 0, Nel3D(3) ; do j = 0, Nel3D(2) ; do i = 0, Nel3D(1)
-               dS(:,i,k) = dS(:,i,k) + geom % jGradEta(:,i,j,k) * spAe(2) % v(j,BACK)
-               GradXi  (:,i,k) = GradXi  (:,i,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,BACK)
-               GradEta (:,i,k) = GradEta (:,i,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,BACK)
-               GradZeta(:,i,k) = GradZeta(:,i,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * spAe(2) % v(j,BACK)
+               dS(:,i,k) = dS(:,i,k) + geom % jGradEta(:,i,j,k) * NodalStorage(Nel3D(2)) % v(j,BACK)
+               GradXi  (:,i,k) = GradXi  (:,i,k) + geom % jGradXi  (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,BACK)
+               GradEta (:,i,k) = GradEta (:,i,k) + geom % jGradEta (:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,BACK)
+               GradZeta(:,i,k) = GradZeta(:,i,k) + geom % jGradZeta(:,i,j,k) * geom % invJacobian(i,j,k) * NodalStorage(Nel3D(2)) % v(j,BACK)
             end do           ; end do           ; end do
 
       end select
@@ -734,7 +732,7 @@ Module MappedGeometryClass
 !     -----------------------
       self % t1 = 0.0_RP
       do j = 0, Nf(2)   ; do l = 0, Nf(1)    ; do i = 0, Nf(1)
-         self % t1(:,i,j) = self % t1(:,i,j) + spAf(1) % D(i,l) * self % x(:,l,j)
+         self % t1(:,i,j) = self % t1(:,i,j) + NodalStorage(Nf(1)) % D(i,l) * self % x(:,l,j)
       end do            ; end do             ; end do
 !
 !     Tangent vectors could not be orthogonal to normal vectors (because of truncation errors)
@@ -753,7 +751,7 @@ Module MappedGeometryClass
 !
       self % surface = 0.0_RP
       do j = 0, Nf(2) ; do i = 0, Nf(1)
-         self % surface = self % surface + spAf(1) % w(i) * spAf(2) % w(j) * self % jacobian(i,j)
+         self % surface = self % surface + NodalStorage(Nf(1)) % w(i) * NodalStorage(Nf(2)) % w(j) * self % jacobian(i,j)
       end do          ; end do
 
 


### PR DESCRIPTION
Avoid passing NodalStorage as an argument to ConstructMappedGeometryFace. Use the NodalStorage from the import instead.